### PR TITLE
chore: add detect-secrets pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+        exclude: |
+          (?x)^(
+            .*\.lock$|
+            .*package-lock\.json$|
+            .*\.env\.example$|
+            data/.*\.json$
+          )$

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,42 @@
+{
+  "version": "1.4.0",
+  "plugins_used": [
+    {"name": "ArtifactoryDetector"},
+    {"name": "AWSKeyDetector"},
+    {"name": "AzureStorageKeyDetector"},
+    {"name": "BasicAuthDetector"},
+    {"name": "CloudantDetector"},
+    {"name": "DiscordBotTokenDetector"},
+    {"name": "GitHubTokenDetector"},
+    {"name": "HexHighEntropyString", "limit": 3.0},
+    {"name": "IbmCloudIamDetector"},
+    {"name": "IbmCosHmacDetector"},
+    {"name": "JwtTokenDetector"},
+    {"name": "KeywordDetector", "keyword_exclude": ""},
+    {"name": "MailchimpDetector"},
+    {"name": "NpmDetector"},
+    {"name": "PrivateKeyDetector"},
+    {"name": "SendGridDetector"},
+    {"name": "SlackDetector"},
+    {"name": "SoftlayerDetector"},
+    {"name": "SquareOAuthDetector"},
+    {"name": "StripeDetector"},
+    {"name": "TwilioKeyDetector"}
+  ],
+  "filters_used": [
+    {"path": "detect_secrets.filters.allowlist.is_line_allowlist"},
+    {"path": "detect_secrets.filters.common.is_baseline_file", "filename": ".secrets.baseline"},
+    {"path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies", "min_level": 2},
+    {"path": "detect_secrets.filters.heuristic.is_indirect_reference"},
+    {"path": "detect_secrets.filters.heuristic.is_likely_id_string"},
+    {"path": "detect_secrets.filters.heuristic.is_lock_file"},
+    {"path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"},
+    {"path": "detect_secrets.filters.heuristic.is_potential_uuid"},
+    {"path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"},
+    {"path": "detect_secrets.filters.heuristic.is_sequential_string"},
+    {"path": "detect_secrets.filters.heuristic.is_swagger_file"},
+    {"path": "detect_secrets.filters.heuristic.is_templated_secret"}
+  ],
+  "results": {},
+  "generated_at": "2026-03-01T22:00:00Z"
+}

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ make health        # Check all endpoints
 make clean         # Stop + remove volumes
 ```
 
+## Security
+
+This project uses [detect-secrets](https://github.com/Yelp/detect-secrets) to prevent accidental secret commits.
+
+```bash
+# Install pre-commit hooks
+pip install pre-commit detect-secrets
+pre-commit install
+
+# Update baseline after intentional changes
+detect-secrets scan > .secrets.baseline
+```
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with detect-secrets v1.4.0
- Generate `.secrets.baseline` with 21 detector plugins
- Exclude `.env.example`, lock files, and data JSONs from scanning
- Add security setup instructions to README

Closes #21

## Test plan
- [ ] `pip install pre-commit detect-secrets && pre-commit install`
- [ ] Verify hook blocks commits containing secrets
- [ ] Verify `.env.example` files are excluded from scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)