### PR TITLE
fix(ci): fix remaining client TS and ai-director test failures

### DIFF
--- a/client/src/nakama/storage.ts
+++ b/client/src/nakama/storage.ts
@@ -4,12 +4,9 @@ import type { PlayerProfile, GameState } from "../types/game";
 export async function getPlayerProfile(): Promise<PlayerProfile | null> {
   const session = getSession();
   if (!session) return null;
-  const result = await nakamaClient.rpc(session, "get_player_profile", "");
+  const result = await nakamaClient.rpc(session, "get_player_profile", {});
   if (!result.payload) return null;
-  const data = typeof result.payload === "string"
-    ? JSON.parse(result.payload)
-    : result.payload;
-  return data as PlayerProfile;
+  return result.payload as unknown as PlayerProfile;
 }
 
 export async function savePlayerProfile(
@@ -20,28 +17,22 @@ export async function savePlayerProfile(
   const result = await nakamaClient.rpc(
     session,
     "save_player_profile",
-    JSON.stringify(profile)
+    profile as unknown as object
   );
   if (!result.payload) throw new Error("No response from server");
-  const data = typeof result.payload === "string"
-    ? JSON.parse(result.payload)
-    : result.payload;
-  return data as PlayerProfile;
+  return result.payload as unknown as PlayerProfile;
 }
 
 export async function getGameState(): Promise<GameState | null> {
   const session = getSession();
   if (!session) return null;
-  const result = await nakamaClient.rpc(session, "get_game_state", "");
+  const result = await nakamaClient.rpc(session, "get_game_state", {});
   if (!result.payload) return null;
-  const data = typeof result.payload === "string"
-    ? JSON.parse(result.payload)
-    : result.payload;
-  return data as GameState;
+  return result.payload as unknown as GameState;
 }
 
 export async function saveGameState(state: GameState): Promise<void> {
   const session = getSession();
   if (!session) throw new Error("Not authenticated");
-  await nakamaClient.rpc(session, "save_game_state", JSON.stringify(state));
+  await nakamaClient.rpc(session, "save_game_state", state as unknown as object);
 }

--- a/services/ai-director/tests/conftest.py
+++ b/services/ai-director/tests/conftest.py
@@ -14,7 +14,30 @@ class MockLLMClient(LLMClient):
     async def generate(
         self, prompt: str, system: str = "", max_tokens: int = 2000
     ) -> str:
-        if "quest" in prompt.lower():
+        # Check "recommend" before "quest" because recommend prompts may
+        # contain "quest_..." in the recent_content list
+        if "recommend game content" in prompt.lower():
+            return json.dumps(
+                {
+                    "recommendations": [
+                        {
+                            "content_type": "dungeon",
+                            "content_id": "dungeon_1",
+                            "reason": "Matches play style",
+                            "priority": 8,
+                        }
+                    ]
+                }
+            )
+        if "evaluate" in prompt.lower() or "session" in prompt.lower():
+            return json.dumps(
+                {
+                    "difficulty_adjustment": 0.2,
+                    "recommendations": ["Increase enemy density"],
+                    "engagement_score": 0.75,
+                }
+            )
+        if "generate a quest" in prompt.lower() or ("quest" in prompt.lower() and "dungeon" not in prompt.lower()):
             return json.dumps(
                 {
                     "title": "Test Quest",
@@ -64,14 +87,6 @@ class MockLLMClient(LLMClient):
                             "risk_level": "low",
                         },
                     ],
-                }
-            )
-        if "evaluate" in prompt.lower() or "session" in prompt.lower():
-            return json.dumps(
-                {
-                    "difficulty_adjustment": 0.2,
-                    "recommendations": ["Increase enemy density"],
-                    "engagement_score": 0.75,
                 }
             )
         if "recommend" in prompt.lower():


### PR DESCRIPTION
## Summary
- Fix client `rpc()` calls to pass objects instead of strings (Nakama JS SDK requirement)
- Reorder AI Director mock conditions to prevent false "quest" match on recommend prompts

Cherry-picked from `1c24192` which was missed in PR #40 merge.