### PR TITLE
feat: implement Boss Fight Corrupted Guardian with 2-phase AI

### DIFF
--- a/client/src/game/entities/bosses/BossAI.ts
+++ b/client/src/game/entities/bosses/BossAI.ts
@@ -1,0 +1,263 @@
+/**
+ * Boss AI state machine for the Corrupted Guardian.
+ *
+ * States: IDLE -> TELEGRAPH -> ATTACK -> RECOVERY -> repeat
+ * Special states: PHASE_TRANSITION, ENRAGED, DEAD
+ *
+ * The boss AI selects attacks from a phase-specific attack table,
+ * respects cooldowns, and manages vulnerability windows during recovery.
+ */
+
+import type { CorruptedGuardian } from './CorruptedGuardian'
+import type { BossAttackConfig } from './BossConfig'
+
+/** All valid boss AI states. */
+export enum BossAIState {
+  IDLE = 'IDLE',
+  TELEGRAPH = 'TELEGRAPH',
+  ATTACK = 'ATTACK',
+  RECOVERY = 'RECOVERY',
+  PHASE_TRANSITION = 'PHASE_TRANSITION',
+  ENRAGED = 'ENRAGED',
+  DEAD = 'DEAD',
+}
+
+/**
+ * Boss AI controller -- manages state transitions and attack selection.
+ *
+ * Unlike the EnemyFSM which uses separate State classes, the boss AI
+ * uses an inline state machine because boss states are tightly coupled
+ * to the boss entity's phase system and attack configs.
+ */
+export class BossAI {
+  private boss: CorruptedGuardian
+  private _state: BossAIState = BossAIState.IDLE
+  private _previousState: BossAIState = BossAIState.IDLE
+
+  // Timers
+  private stateTimer = 0
+  private idleDuration = 800 // ms between attack cycles
+  private phaseTransitionDuration = 2000 // 2s invincible roar
+
+  // Current attack
+  private _currentAttack: BossAttackConfig | null = null
+  private attackCooldowns: Map<string, number> = new Map()
+
+  // Enrage timer
+  private enrageTimer: number
+  private enrageActive = false
+
+  private debug: boolean
+
+  constructor(boss: CorruptedGuardian, debug = false) {
+    this.boss = boss
+    this.debug = debug
+    this.enrageTimer = boss.config.enrageTimerMs
+  }
+
+  /** Current AI state. */
+  get state(): BossAIState {
+    return this._state
+  }
+
+  /** Previous AI state. */
+  get previousState(): BossAIState {
+    return this._previousState
+  }
+
+  /** The attack currently being telegraphed or executed. */
+  get currentAttack(): BossAttackConfig | null {
+    return this._currentAttack
+  }
+
+  /** Whether the enrage timer has expired. */
+  get isEnraged(): boolean {
+    return this.enrageActive
+  }
+
+  /**
+   * Transition to a new AI state.
+   * Handles enter/exit logic for each state.
+   */
+  transition(newState: BossAIState): void {
+    if (this.debug) {
+      console.log(`[BossAI] ${this._state} -> ${newState}`)
+    }
+
+    this._previousState = this._state
+    this._state = newState
+    this.stateTimer = 0
+
+    // Enter logic
+    switch (newState) {
+      case BossAIState.IDLE:
+        this.boss.setVelocity(0, 0)
+        break
+
+      case BossAIState.TELEGRAPH:
+        this.boss.setVelocity(0, 0)
+        this.boss.scene.events.emit('boss-telegraph', this.boss, this._currentAttack)
+        break
+
+      case BossAIState.ATTACK:
+        this.boss.scene.events.emit('boss-attack', this.boss, this._currentAttack)
+        break
+
+      case BossAIState.RECOVERY:
+        this.boss.setVelocity(0, 0)
+        this.boss.isVulnerable = true
+        this.boss.scene.events.emit('boss-recovery', this.boss)
+        break
+
+      case BossAIState.PHASE_TRANSITION:
+        this.boss.setVelocity(0, 0)
+        this.boss.isInvulnerable = true
+        this.boss.scene.events.emit('boss-phase-transition', this.boss)
+        break
+
+      case BossAIState.ENRAGED:
+        this.enrageActive = true
+        this.boss.scene.events.emit('boss-enraged', this.boss)
+        break
+
+      case BossAIState.DEAD:
+        this.boss.setVelocity(0, 0)
+        this.boss.scene.events.emit('boss-defeated', this.boss)
+        break
+    }
+  }
+
+  /**
+   * Per-frame update. Delegates to the current state's logic.
+   */
+  update(delta: number): void {
+    if (this._state === BossAIState.DEAD) return
+
+    // Update enrage timer
+    this.enrageTimer -= delta
+    if (this.enrageTimer <= 0 && !this.enrageActive) {
+      this.transition(BossAIState.ENRAGED)
+      return
+    }
+
+    // Update attack cooldowns
+    for (const [id, cd] of this.attackCooldowns.entries()) {
+      this.attackCooldowns.set(id, Math.max(0, cd - delta))
+    }
+
+    this.stateTimer += delta
+
+    switch (this._state) {
+      case BossAIState.IDLE:
+        this.updateIdle(delta)
+        break
+      case BossAIState.TELEGRAPH:
+        this.updateTelegraph(delta)
+        break
+      case BossAIState.ATTACK:
+        this.updateAttack(delta)
+        break
+      case BossAIState.RECOVERY:
+        this.updateRecovery(delta)
+        break
+      case BossAIState.PHASE_TRANSITION:
+        this.updatePhaseTransition(delta)
+        break
+      case BossAIState.ENRAGED:
+        // In enraged state, use idle logic but faster
+        this.updateIdle(delta)
+        break
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // State updates
+  // ---------------------------------------------------------------------------
+
+  private updateIdle(_delta: number): void {
+    if (this.stateTimer >= this.idleDuration) {
+      // Select next attack
+      const attack = this.selectAttack()
+      if (attack) {
+        this._currentAttack = attack
+        this.transition(BossAIState.TELEGRAPH)
+      }
+    }
+  }
+
+  private updateTelegraph(_delta: number): void {
+    if (!this._currentAttack) {
+      this.transition(BossAIState.IDLE)
+      return
+    }
+
+    if (this.stateTimer >= this._currentAttack.timing.telegraphMs) {
+      this.transition(BossAIState.ATTACK)
+    }
+  }
+
+  private updateAttack(_delta: number): void {
+    if (!this._currentAttack) {
+      this.transition(BossAIState.RECOVERY)
+      return
+    }
+
+    // Emit hit at midpoint of attack
+    const midpoint = this._currentAttack.timing.activeMs * 0.5
+    if (this.stateTimer >= midpoint && this.stateTimer - _delta < midpoint) {
+      this.boss.scene.events.emit(
+        'boss-attack-hit',
+        this.boss,
+        this._currentAttack
+      )
+    }
+
+    if (this.stateTimer >= this._currentAttack.timing.activeMs) {
+      // Set cooldown for this attack
+      this.attackCooldowns.set(
+        this._currentAttack.id,
+        this._currentAttack.timing.cooldownMs
+      )
+      this.transition(BossAIState.RECOVERY)
+    }
+  }
+
+  private updateRecovery(_delta: number): void {
+    if (this.stateTimer >= this.boss.config.vulnerabilityDurationMs) {
+      this.boss.isVulnerable = false
+      this._currentAttack = null
+      this.transition(BossAIState.IDLE)
+    }
+  }
+
+  private updatePhaseTransition(_delta: number): void {
+    if (this.stateTimer >= this.phaseTransitionDuration) {
+      this.boss.isInvulnerable = false
+      this.transition(BossAIState.IDLE)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Attack selection
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Select the next attack from the current phase's attack table.
+   * Respects cooldowns. Returns null if all attacks are on cooldown.
+   */
+  private selectAttack(): BossAttackConfig | null {
+    const phase = this.boss.getCurrentPhase()
+    if (!phase) return null
+
+    const available = phase.attacks.filter((atk) => {
+      const cd = this.attackCooldowns.get(atk.id) ?? 0
+      return cd <= 0
+    })
+
+    if (available.length === 0) return null
+
+    // Simple random selection (could be weighted later)
+    const index = Math.floor(Math.random() * available.length)
+    return available[index]
+  }
+}

--- a/client/src/game/entities/bosses/BossConfig.ts
+++ b/client/src/game/entities/bosses/BossConfig.ts
@@ -1,0 +1,224 @@
+/**
+ * Data-driven configuration for boss entities.
+ *
+ * Extends the base EnemyConfig pattern with boss-specific fields:
+ * phase thresholds, attack tables per phase, vulnerability windows,
+ * enrage timer, and loot configuration.
+ */
+
+import type { Element } from '../../../types/game'
+
+/** Timing configuration for a single boss attack. */
+export interface BossAttackTiming {
+  /** Duration (ms) of the telegraph wind-up. */
+  telegraphMs: number
+  /** Duration (ms) of the active attack. */
+  activeMs: number
+  /** Duration (ms) of the recovery window after the attack. */
+  recoveryMs: number
+  /** Minimum cooldown (ms) before this attack can be used again. */
+  cooldownMs: number
+}
+
+/** Full configuration for a single boss attack. */
+export interface BossAttackConfig {
+  /** Identifier for this attack type. */
+  id: string
+  /** Display name for UI/telegraph indicators. */
+  name: string
+  /** Timing data for telegraph, active, recovery, and cooldown. */
+  timing: BossAttackTiming
+  /** Base damage dealt by this attack. */
+  damage: number
+  /** Range (px) of the attack. */
+  range: number
+  /** Element of the attack (if any). */
+  element: Element | null
+  /** AoE radius (px), 0 for single-target/line attacks. */
+  aoeRadius: number
+  /** Color of the telegraph indicator (hex). */
+  telegraphColor: number
+  /** Color of the attack hitbox (hex). */
+  attackColor: number
+}
+
+/** Phase threshold configuration. */
+export interface BossPhaseConfig {
+  /** Phase identifier. */
+  id: string
+  /** HP percentage threshold to enter this phase (e.g. 0.5 = 50%). */
+  hpThreshold: number
+  /** Attacks available during this phase. */
+  attacks: BossAttackConfig[]
+  /** Speed multiplier for this phase (1.0 = normal). */
+  speedMultiplier: number
+  /** Attack speed multiplier (affects telegraph duration). */
+  attackSpeedMultiplier: number
+  /** Tint applied to the boss sprite during this phase. */
+  tint: number
+}
+
+/** Full boss configuration. */
+export interface BossEntityConfig {
+  /** Display name. */
+  name: string
+  /** Maximum hit points. */
+  maxHp: number
+  /** Base attack damage. */
+  attack: number
+  /** Flat damage reduction. */
+  defense: number
+  /** Base movement speed (px/s). */
+  speed: number
+  /** Elemental affinity. */
+  element: Element | null
+  /** Detection range (px) -- typically arena-wide. */
+  detectionRange: number
+  /** Melee attack range (px). */
+  meleeRange: number
+  /** Ranged attack range (px). */
+  rangedRange: number
+  /** Phase configurations (ordered by HP threshold, descending). */
+  phases: BossPhaseConfig[]
+  /** Duration (ms) of the vulnerability window after each attack. */
+  vulnerabilityDurationMs: number
+  /** Damage multiplier applied during vulnerability windows. */
+  vulnerabilityDamageMult: number
+  /** Enrage timer (ms). Boss enters rage mode when this expires. */
+  enrageTimerMs: number
+  /** XP reward on defeat. */
+  xpReward: number
+  /** HP threshold to summon minions (e.g. 0.75 = 75%). Phase 1 only. */
+  minionSummonThreshold: number
+  /** Number of minions to summon. */
+  minionCount: number
+}
+
+// ---------------------------------------------------------------------------
+// Corrupted Guardian attack definitions
+// ---------------------------------------------------------------------------
+
+const groundSlamP1: BossAttackConfig = {
+  id: 'ground_slam',
+  name: 'Ground Slam',
+  timing: {
+    telegraphMs: 1500,
+    activeMs: 500,
+    recoveryMs: 2000,
+    cooldownMs: 3000,
+  },
+  damage: 50,
+  range: 200,
+  element: 'fire',
+  aoeRadius: 200,
+  telegraphColor: 0xff8800,
+  attackColor: 0xff4400,
+}
+
+const shadowBoltP1: BossAttackConfig = {
+  id: 'shadow_bolt',
+  name: 'Shadow Bolt',
+  timing: {
+    telegraphMs: 1500,
+    activeMs: 300,
+    recoveryMs: 2000,
+    cooldownMs: 3500,
+  },
+  damage: 30,
+  range: 350,
+  element: 'shadow',
+  aoeRadius: 60,
+  telegraphColor: 0x6622cc,
+  attackColor: 0x440088,
+}
+
+const groundSlamP2: BossAttackConfig = {
+  id: 'ground_slam',
+  name: 'Ground Slam',
+  timing: {
+    telegraphMs: 1000,
+    activeMs: 400,
+    recoveryMs: 2000,
+    cooldownMs: 2400,
+  },
+  damage: 65,
+  range: 220,
+  element: 'fire',
+  aoeRadius: 220,
+  telegraphColor: 0xff4400,
+  attackColor: 0xff0000,
+}
+
+const shadowBoltP2: BossAttackConfig = {
+  id: 'shadow_bolt',
+  name: 'Shadow Bolt',
+  timing: {
+    telegraphMs: 1000,
+    activeMs: 200,
+    recoveryMs: 2000,
+    cooldownMs: 2800,
+  },
+  damage: 40,
+  range: 350,
+  element: 'shadow',
+  aoeRadius: 60,
+  telegraphColor: 0x440088,
+  attackColor: 0x220044,
+}
+
+const corruptionWave: BossAttackConfig = {
+  id: 'corruption_wave',
+  name: 'Corruption Wave',
+  timing: {
+    telegraphMs: 1000,
+    activeMs: 800,
+    recoveryMs: 2000,
+    cooldownMs: 5000,
+  },
+  damage: 45,
+  range: 400,
+  element: 'void',
+  aoeRadius: 400,
+  telegraphColor: 0x222244,
+  attackColor: 0x110022,
+}
+
+// ---------------------------------------------------------------------------
+// Corrupted Guardian config
+// ---------------------------------------------------------------------------
+
+export const corruptedGuardianConfig: BossEntityConfig = {
+  name: 'Corrupted Guardian',
+  maxHp: 2500,
+  attack: 45,
+  defense: 22,
+  speed: 70,
+  element: 'fire',
+  detectionRange: 800,
+  meleeRange: 120,
+  rangedRange: 300,
+  phases: [
+    {
+      id: 'phase_1',
+      hpThreshold: 1.0,
+      attacks: [groundSlamP1, shadowBoltP1],
+      speedMultiplier: 1.0,
+      attackSpeedMultiplier: 1.0,
+      tint: 0xff4400,
+    },
+    {
+      id: 'phase_2',
+      hpThreshold: 0.5,
+      attacks: [groundSlamP2, shadowBoltP2, corruptionWave],
+      speedMultiplier: 1.3,
+      attackSpeedMultiplier: 1.0,
+      tint: 0xff0000,
+    },
+  ],
+  vulnerabilityDurationMs: 2000,
+  vulnerabilityDamageMult: 1.5,
+  enrageTimerMs: 180000, // 3 minutes
+  xpReward: 500,
+  minionSummonThreshold: 0.75,
+  minionCount: 2,
+}

--- a/client/src/game/entities/bosses/CorruptedGuardian.ts
+++ b/client/src/game/entities/bosses/CorruptedGuardian.ts
@@ -1,0 +1,250 @@
+/**
+ * Corrupted Guardian -- First boss entity.
+ *
+ * A 2-phase boss fight with telegraphed attacks, vulnerability windows,
+ * and an enrage timer. Uses the BossAI state machine for behavior and
+ * BossConfig for data-driven attack/phase configuration.
+ *
+ * Phase 1 (100%-50% HP):
+ *   - Ground Slam (1.5s telegraph, AoE)
+ *   - Shadow Bolt (projectile, straight line)
+ *   - Summons 2 shadow minions at 75% HP
+ *
+ * Phase 2 (50%-0% HP):
+ *   - Rage mode (increased speed, red glow)
+ *   - Corruption Wave (AoE ring, must dodge through)
+ *   - Faster telegraphs (1.0s instead of 1.5s)
+ *   - 3 minute enrage timer
+ */
+
+import Phaser from 'phaser'
+import { BossAI, BossAIState } from './BossAI'
+import type { BossEntityConfig, BossPhaseConfig } from './BossConfig'
+import { corruptedGuardianConfig } from './BossConfig'
+
+/** Tint color for the Corrupted Guardian based on element. */
+const BOSS_TINT = 0xff4400
+
+/** Size of the boss sprite (2.5x player size). */
+const BOSS_WIDTH = 64
+const BOSS_HEIGHT = 96
+
+/**
+ * Corrupted Guardian boss entity.
+ *
+ * This is a Phaser Arcade Sprite with:
+ *   - BossAI state machine for attack patterns
+ *   - Phase management (HP-threshold transitions)
+ *   - Vulnerability/invulnerability flags
+ *   - HP bar and telegraph visual indicators
+ */
+export class CorruptedGuardian extends Phaser.Physics.Arcade.Sprite {
+  public ai!: BossAI
+  public config: BossEntityConfig
+
+  // Combat state
+  public health: number
+  public maxHealth: number
+  public isInvulnerable = false
+  public isVulnerable = false
+
+  // Phase tracking
+  private currentPhaseIndex = 0
+  private minionsSummoned = false
+
+  // Player reference
+  private playerRef: Phaser.Physics.Arcade.Sprite | null = null
+
+  constructor(scene: Phaser.Scene, x: number, y: number) {
+    // Create placeholder boss texture
+    if (!scene.textures.exists('boss_corrupted_guardian')) {
+      const gfx = scene.add.graphics()
+      gfx.fillStyle(BOSS_TINT, 1)
+      gfx.fillRect(0, 0, BOSS_WIDTH, BOSS_HEIGHT)
+      // Add "eyes" to distinguish from regular enemies
+      gfx.fillStyle(0xff8800, 1)
+      gfx.fillCircle(20, 20, 6)
+      gfx.fillCircle(44, 20, 6)
+      gfx.generateTexture('boss_corrupted_guardian', BOSS_WIDTH, BOSS_HEIGHT)
+      gfx.destroy()
+    }
+
+    super(scene, x, y, 'boss_corrupted_guardian')
+
+    this.config = corruptedGuardianConfig
+    this.health = this.config.maxHp
+    this.maxHealth = this.config.maxHp
+
+    scene.add.existing(this)
+    scene.physics.add.existing(this)
+
+    this.setCollideWorldBounds(true)
+    this.setSize(BOSS_WIDTH, BOSS_HEIGHT)
+    this.setOrigin(0.5, 0.5)
+    this.setTint(BOSS_TINT)
+
+    // Initialize AI
+    this.ai = new BossAI(this, true)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Called every frame by the scene.
+   * Updates the AI state machine and checks phase transitions.
+   */
+  update(_time: number, delta: number): void {
+    if (this.ai.state === BossAIState.DEAD) return
+
+    this.ai.update(delta)
+    this.checkPhaseTransition()
+    this.checkMinionSummon()
+    this.updateVisuals()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Player reference
+  // ---------------------------------------------------------------------------
+
+  /** Set the player reference for targeting. */
+  setPlayer(player: Phaser.Physics.Arcade.Sprite): void {
+    this.playerRef = player
+  }
+
+  /** Distance to the tracked player. */
+  distanceToPlayer(): number | null {
+    if (!this.playerRef || !this.playerRef.active) return null
+    const dx = this.playerRef.x - this.x
+    const dy = this.playerRef.y - this.y
+    return Math.sqrt(dx * dx + dy * dy)
+  }
+
+  /** Player position for attack targeting. */
+  getPlayerPosition(): { x: number; y: number } | null {
+    if (!this.playerRef || !this.playerRef.active) return null
+    return { x: this.playerRef.x, y: this.playerRef.y }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Phase management
+  // ---------------------------------------------------------------------------
+
+  /** Get the current phase config based on the phase index. */
+  getCurrentPhase(): BossPhaseConfig | null {
+    return this.config.phases[this.currentPhaseIndex] ?? null
+  }
+
+  /** Get the current phase index (0 = phase 1, 1 = phase 2). */
+  getPhaseIndex(): number {
+    return this.currentPhaseIndex
+  }
+
+  private checkPhaseTransition(): void {
+    const hpRatio = this.health / this.maxHealth
+    const nextPhaseIndex = this.currentPhaseIndex + 1
+
+    if (nextPhaseIndex >= this.config.phases.length) return
+
+    const nextPhase = this.config.phases[nextPhaseIndex]
+    if (hpRatio <= nextPhase.hpThreshold) {
+      this.currentPhaseIndex = nextPhaseIndex
+      this.ai.transition(BossAIState.PHASE_TRANSITION)
+
+      this.scene.events.emit(
+        'boss-phase-changed',
+        this,
+        nextPhase.id,
+        this.currentPhaseIndex
+      )
+    }
+  }
+
+  private checkMinionSummon(): void {
+    if (this.minionsSummoned) return
+    if (this.currentPhaseIndex !== 0) return // Phase 1 only
+
+    const hpRatio = this.health / this.maxHealth
+    if (hpRatio <= this.config.minionSummonThreshold) {
+      this.minionsSummoned = true
+      this.scene.events.emit(
+        'boss-summon-minions',
+        this,
+        this.config.minionCount
+      )
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Combat
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Apply damage to the boss.
+   * Respects invulnerability (phase transitions) and vulnerability
+   * bonus (+50% during recovery windows).
+   */
+  takeDamage(rawAmount: number): void {
+    if (this.isInvulnerable) return
+
+    let amount = rawAmount
+
+    // Vulnerability bonus during recovery window
+    if (this.isVulnerable) {
+      amount = Math.floor(amount * this.config.vulnerabilityDamageMult)
+    }
+
+    this.health = Math.max(0, this.health - amount)
+
+    this.scene.events.emit(
+      'boss-health-changed',
+      this,
+      this.health,
+      this.maxHealth
+    )
+
+    if (this.health <= 0) {
+      this.die()
+    }
+  }
+
+  /** Kill the boss immediately. */
+  die(): void {
+    this.health = 0
+    this.ai.transition(BossAIState.DEAD)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Visuals
+  // ---------------------------------------------------------------------------
+
+  private updateVisuals(): void {
+    const phase = this.getCurrentPhase()
+    if (!phase) return
+
+    // Apply phase tint
+    if (this.ai.state === BossAIState.TELEGRAPH) {
+      // Orange flash during telegraph
+      this.setTint(0xff8800)
+    } else if (this.ai.state === BossAIState.ATTACK) {
+      // Red flash during attack
+      this.setTint(0xff0000)
+    } else if (this.ai.state === BossAIState.RECOVERY) {
+      // Blue-white flash during vulnerability
+      this.setTint(0x88bbff)
+    } else if (this.ai.state === BossAIState.PHASE_TRANSITION) {
+      // Purple flash during phase transition
+      this.setTint(0xaa00ff)
+    } else {
+      // Default phase tint
+      this.setTint(phase.tint)
+    }
+
+    // Enrage visual: pulsing red
+    if (this.ai.isEnraged && this.ai.state !== BossAIState.DEAD) {
+      const pulse = Math.abs(Math.sin(Date.now() / 200)) * 0.5 + 0.5
+      this.setAlpha(pulse)
+    }
+  }
+}

--- a/client/src/game/entities/bosses/attacks/CorruptionWave.ts
+++ b/client/src/game/entities/bosses/attacks/CorruptionWave.ts
@@ -1,0 +1,185 @@
+/**
+ * Corruption Wave attack for the Corrupted Guardian (Phase 2 only).
+ *
+ * An expanding ring of corruption that emanates from the boss.
+ * The player must dodge THROUGH the wave (not away from it) to
+ * avoid damage, since the ring expands outward.
+ *
+ * Telegraph: Purple circle at boss position, growing to show
+ * the wave's path. Active: Ring expands rapidly outward.
+ */
+
+import Phaser from 'phaser'
+import type { BossAttackConfig } from '../BossConfig'
+
+/** Speed at which the wave ring expands (px/s). */
+const WAVE_EXPAND_SPEED = 400
+
+/** Thickness of the damage ring (px). */
+const RING_THICKNESS = 40
+
+/**
+ * Visual and gameplay representation of the Corruption Wave.
+ *
+ * The wave is an expanding ring centered on the boss. The damage
+ * zone is a torus (donut shape) -- the player takes damage only
+ * if they are within the ring's thickness as it passes over them.
+ */
+export class CorruptionWave {
+  private scene: Phaser.Scene
+  private config: BossAttackConfig
+  private centerX: number
+  private centerY: number
+  private graphics: Phaser.GameObjects.Graphics
+  private elapsed = 0
+  private phase: 'telegraph' | 'active' | 'done' = 'telegraph'
+  private currentRadius = 0
+
+  constructor(
+    scene: Phaser.Scene,
+    config: BossAttackConfig,
+    centerX: number,
+    centerY: number
+  ) {
+    this.scene = scene
+    this.config = config
+    this.centerX = centerX
+    this.centerY = centerY
+
+    this.graphics = scene.add.graphics()
+    this.graphics.setDepth(10)
+  }
+
+  /**
+   * Update the wave visual and expansion.
+   * Returns true when the attack is fully resolved.
+   */
+  update(delta: number): boolean {
+    this.elapsed += delta
+
+    if (this.phase === 'telegraph') {
+      this.drawTelegraph()
+
+      if (this.elapsed >= this.config.timing.telegraphMs) {
+        this.phase = 'active'
+        this.elapsed = 0
+        this.currentRadius = 0
+      }
+      return false
+    }
+
+    if (this.phase === 'active') {
+      // Expand the ring
+      this.currentRadius += (WAVE_EXPAND_SPEED * delta) / 1000
+      this.drawWave()
+
+      if (this.currentRadius >= this.config.aoeRadius) {
+        this.phase = 'done'
+        this.destroy()
+        return true
+      }
+      return false
+    }
+
+    return true
+  }
+
+  /** Clean up graphics. */
+  destroy(): void {
+    this.graphics.destroy()
+  }
+
+  /**
+   * Get the damage ring zone for collision checks.
+   * The damage zone is a ring (torus): player is hit if their
+   * distance from center is between (currentRadius - thickness/2)
+   * and (currentRadius + thickness/2).
+   */
+  getDamageRing(): {
+    x: number
+    y: number
+    innerRadius: number
+    outerRadius: number
+  } {
+    return {
+      x: this.centerX,
+      y: this.centerY,
+      innerRadius: Math.max(0, this.currentRadius - RING_THICKNESS / 2),
+      outerRadius: this.currentRadius + RING_THICKNESS / 2,
+    }
+  }
+
+  /**
+   * Check if a point is within the damage ring.
+   * Used for collision detection with the player.
+   */
+  isPointInDamageZone(px: number, py: number): boolean {
+    if (this.phase !== 'active') return false
+
+    const dx = px - this.centerX
+    const dy = py - this.centerY
+    const dist = Math.sqrt(dx * dx + dy * dy)
+    const ring = this.getDamageRing()
+
+    return dist >= ring.innerRadius && dist <= ring.outerRadius
+  }
+
+  private drawTelegraph(): void {
+    this.graphics.clear()
+
+    const progress = Math.min(this.elapsed / this.config.timing.telegraphMs, 1)
+
+    // Pulsing concentric rings showing the wave's path
+    const ringCount = 3
+    for (let i = 0; i < ringCount; i++) {
+      const ringProgress = (progress + i / ringCount) % 1
+      const radius = this.config.aoeRadius * ringProgress
+      const alpha = (1 - ringProgress) * 0.4
+
+      this.graphics.lineStyle(2, this.config.telegraphColor, alpha)
+      this.graphics.strokeCircle(this.centerX, this.centerY, radius)
+    }
+
+    // Center marker
+    const pulse = Math.sin(this.elapsed / 150) * 0.3 + 0.7
+    this.graphics.fillStyle(0x222244, pulse * 0.5)
+    this.graphics.fillCircle(this.centerX, this.centerY, 20)
+  }
+
+  private drawWave(): void {
+    this.graphics.clear()
+
+    // The expanding damage ring
+    const innerR = Math.max(0, this.currentRadius - RING_THICKNESS / 2)
+    const outerR = this.currentRadius + RING_THICKNESS / 2
+
+    // Draw the ring using arc paths
+    // Outer circle
+    this.graphics.fillStyle(this.config.attackColor, 0.4)
+    this.graphics.beginPath()
+    this.graphics.arc(
+      this.centerX,
+      this.centerY,
+      outerR,
+      0,
+      Math.PI * 2,
+      false
+    )
+    this.graphics.arc(
+      this.centerX,
+      this.centerY,
+      innerR,
+      Math.PI * 2,
+      0,
+      true
+    )
+    this.graphics.closePath()
+    this.graphics.fillPath()
+
+    // Edge glow
+    this.graphics.lineStyle(2, 0x6622cc, 0.8)
+    this.graphics.strokeCircle(this.centerX, this.centerY, outerR)
+    this.graphics.lineStyle(1, 0x222244, 0.5)
+    this.graphics.strokeCircle(this.centerX, this.centerY, innerR)
+  }
+}

--- a/client/src/game/entities/bosses/attacks/GroundSlam.ts
+++ b/client/src/game/entities/bosses/attacks/GroundSlam.ts
@@ -1,0 +1,126 @@
+/**
+ * Ground Slam attack for the Corrupted Guardian.
+ *
+ * Phase 1: 1.5s telegraph, circular AoE at player position.
+ * Phase 2: 1.0s telegraph, larger AoE, more damage.
+ *
+ * The telegraph shows a growing circle at the target position.
+ * The player must dodge out of the AoE before the slam lands.
+ */
+
+import Phaser from 'phaser'
+import type { BossAttackConfig } from '../BossConfig'
+
+/**
+ * Visual representation of the Ground Slam attack.
+ *
+ * Creates a telegraph circle that grows during the wind-up,
+ * then flashes red on impact. The circle is a scene-owned
+ * graphics object that self-destructs after the attack resolves.
+ */
+export class GroundSlam {
+  private scene: Phaser.Scene
+  private config: BossAttackConfig
+  private targetX: number
+  private targetY: number
+  private graphics: Phaser.GameObjects.Graphics
+  private elapsed = 0
+  private phase: 'telegraph' | 'active' | 'done' = 'telegraph'
+
+  constructor(
+    scene: Phaser.Scene,
+    config: BossAttackConfig,
+    targetX: number,
+    targetY: number
+  ) {
+    this.scene = scene
+    this.config = config
+    this.targetX = targetX
+    this.targetY = targetY
+
+    this.graphics = scene.add.graphics()
+    this.graphics.setDepth(10)
+  }
+
+  /**
+   * Update the visual representation.
+   * Returns true when the attack is fully resolved.
+   */
+  update(delta: number): boolean {
+    this.elapsed += delta
+
+    if (this.phase === 'telegraph') {
+      this.drawTelegraph()
+
+      if (this.elapsed >= this.config.timing.telegraphMs) {
+        this.phase = 'active'
+        this.elapsed = 0
+      }
+      return false
+    }
+
+    if (this.phase === 'active') {
+      this.drawImpact()
+
+      if (this.elapsed >= this.config.timing.activeMs) {
+        this.phase = 'done'
+        this.destroy()
+        return true
+      }
+      return false
+    }
+
+    return true
+  }
+
+  /** Clean up graphics. */
+  destroy(): void {
+    this.graphics.destroy()
+  }
+
+  /** Get the damage zone for collision checks. */
+  getDamageZone(): { x: number; y: number; radius: number } {
+    return {
+      x: this.targetX,
+      y: this.targetY,
+      radius: this.config.aoeRadius,
+    }
+  }
+
+  private drawTelegraph(): void {
+    this.graphics.clear()
+
+    // Growing circle that fills over the telegraph duration
+    const progress = Math.min(this.elapsed / this.config.timing.telegraphMs, 1)
+    const currentRadius = this.config.aoeRadius * progress
+
+    // Outer warning ring
+    this.graphics.lineStyle(3, this.config.telegraphColor, 0.6)
+    this.graphics.strokeCircle(this.targetX, this.targetY, this.config.aoeRadius)
+
+    // Inner growing fill
+    this.graphics.fillStyle(this.config.telegraphColor, 0.2 + progress * 0.3)
+    this.graphics.fillCircle(this.targetX, this.targetY, currentRadius)
+
+    // Pulsing center marker
+    const pulse = Math.sin(this.elapsed / 100) * 0.3 + 0.7
+    this.graphics.fillStyle(0xff0000, pulse)
+    this.graphics.fillCircle(this.targetX, this.targetY, 8)
+  }
+
+  private drawImpact(): void {
+    this.graphics.clear()
+
+    // Flash red on impact, then fade
+    const progress = this.elapsed / this.config.timing.activeMs
+    const alpha = 1 - progress
+
+    this.graphics.fillStyle(this.config.attackColor, alpha * 0.6)
+    this.graphics.fillCircle(this.targetX, this.targetY, this.config.aoeRadius)
+
+    // Shockwave ring expanding outward
+    const ringRadius = this.config.aoeRadius * (1 + progress * 0.3)
+    this.graphics.lineStyle(4, 0xff0000, alpha)
+    this.graphics.strokeCircle(this.targetX, this.targetY, ringRadius)
+  }
+}

--- a/client/src/game/entities/bosses/attacks/ShadowBolt.ts
+++ b/client/src/game/entities/bosses/attacks/ShadowBolt.ts
@@ -1,0 +1,155 @@
+/**
+ * Shadow Bolt attack for the Corrupted Guardian.
+ *
+ * A straight-line projectile that travels from the boss toward the
+ * player's position at the time of firing. Medium speed, explodes
+ * on contact with a small AoE blast radius.
+ */
+
+import Phaser from 'phaser'
+import type { BossAttackConfig } from '../BossConfig'
+
+/** Projectile speed in pixels per second. */
+const PROJECTILE_SPEED = 250
+
+/** Size of the shadow bolt projectile. */
+const BOLT_RADIUS = 12
+
+/**
+ * Visual and gameplay representation of the Shadow Bolt projectile.
+ *
+ * The bolt is a scene-owned graphics object that travels in a straight
+ * line toward the target position. It self-destructs after reaching
+ * the target or exceeding max range.
+ */
+export class ShadowBolt {
+  private scene: Phaser.Scene
+  private config: BossAttackConfig
+  private graphics: Phaser.GameObjects.Graphics
+  private x: number
+  private y: number
+  private velocityX: number
+  private velocityY: number
+  private distanceTraveled = 0
+  private _active = true
+
+  constructor(
+    scene: Phaser.Scene,
+    config: BossAttackConfig,
+    startX: number,
+    startY: number,
+    targetX: number,
+    targetY: number
+  ) {
+    this.scene = scene
+    this.config = config
+    this.x = startX
+    this.y = startY
+
+    // Calculate velocity toward target
+    const dx = targetX - startX
+    const dy = targetY - startY
+    const len = Math.sqrt(dx * dx + dy * dy)
+
+    if (len > 0) {
+      this.velocityX = (dx / len) * PROJECTILE_SPEED
+      this.velocityY = (dy / len) * PROJECTILE_SPEED
+    } else {
+      this.velocityX = PROJECTILE_SPEED
+      this.velocityY = 0
+    }
+
+    this.graphics = scene.add.graphics()
+    this.graphics.setDepth(15)
+  }
+
+  /** Whether the projectile is still in flight. */
+  get active(): boolean {
+    return this._active
+  }
+
+  /**
+   * Update projectile position and visuals.
+   * Returns true when the projectile should be removed.
+   */
+  update(delta: number): boolean {
+    if (!this._active) return true
+
+    // Move
+    const dtSeconds = delta / 1000
+    this.x += this.velocityX * dtSeconds
+    this.y += this.velocityY * dtSeconds
+    this.distanceTraveled += PROJECTILE_SPEED * dtSeconds
+
+    // Check max range
+    if (this.distanceTraveled >= this.config.range) {
+      this.explode()
+      return true
+    }
+
+    // Draw
+    this.draw()
+    return false
+  }
+
+  /** Get the current hitbox for collision checks. */
+  getHitbox(): { x: number; y: number; radius: number } {
+    return { x: this.x, y: this.y, radius: BOLT_RADIUS }
+  }
+
+  /** Get the explosion zone (larger than the bolt itself). */
+  getExplosionZone(): { x: number; y: number; radius: number } {
+    return { x: this.x, y: this.y, radius: this.config.aoeRadius }
+  }
+
+  /** Trigger the explosion effect and deactivate. */
+  explode(): void {
+    this._active = false
+
+    // Draw explosion
+    this.graphics.clear()
+    this.graphics.fillStyle(this.config.attackColor, 0.5)
+    this.graphics.fillCircle(this.x, this.y, this.config.aoeRadius)
+    this.graphics.lineStyle(2, 0x6622cc, 0.8)
+    this.graphics.strokeCircle(this.x, this.y, this.config.aoeRadius)
+
+    // Fade out and destroy after a short delay
+    this.scene.tweens.add({
+      targets: this.graphics,
+      alpha: 0,
+      duration: 300,
+      onComplete: () => {
+        this.graphics.destroy()
+      },
+    })
+  }
+
+  /** Clean up immediately. */
+  destroy(): void {
+    this._active = false
+    this.graphics.destroy()
+  }
+
+  private draw(): void {
+    this.graphics.clear()
+
+    // Core bolt
+    this.graphics.fillStyle(0x6622cc, 1)
+    this.graphics.fillCircle(this.x, this.y, BOLT_RADIUS)
+
+    // Outer glow
+    this.graphics.fillStyle(0x440088, 0.4)
+    this.graphics.fillCircle(this.x, this.y, BOLT_RADIUS * 1.8)
+
+    // Trail particles (3 trailing dots)
+    const trailSpacing = 15
+    for (let i = 1; i <= 3; i++) {
+      const trailX = this.x - (this.velocityX / PROJECTILE_SPEED) * trailSpacing * i
+      const trailY = this.y - (this.velocityY / PROJECTILE_SPEED) * trailSpacing * i
+      const trailAlpha = 0.6 - i * 0.15
+      const trailSize = BOLT_RADIUS * (1 - i * 0.2)
+      this.graphics.fillStyle(0x6622cc, trailAlpha)
+      this.graphics.fillCircle(trailX, trailY, trailSize)
+    }
+  }
+}

--- a/client/src/game/entities/bosses/index.ts
+++ b/client/src/game/entities/bosses/index.ts
@@ -1,0 +1,12 @@
+export { CorruptedGuardian } from './CorruptedGuardian'
+export { BossAI, BossAIState } from './BossAI'
+export type {
+  BossEntityConfig,
+  BossPhaseConfig,
+  BossAttackConfig,
+  BossAttackTiming,
+} from './BossConfig'
+export { corruptedGuardianConfig } from './BossConfig'
+export { GroundSlam } from './attacks/GroundSlam'
+export { ShadowBolt } from './attacks/ShadowBolt'
+export { CorruptionWave } from './attacks/CorruptionWave'

--- a/services/game-logic/app/api/boss.py
+++ b/services/game-logic/app/api/boss.py
@@ -1,0 +1,98 @@
+"""Boss fight API endpoints.
+
+Provides REST endpoints for the Corrupted Guardian boss encounter:
+- Start a boss fight
+- Deal damage to the boss
+- Request the boss's next attack
+- Notify recovery state transitions
+- Collect loot on defeat
+"""
+
+from fastapi import APIRouter, HTTPException, Request
+
+from app.models.boss_schemas import (
+    BossAttackRequest,
+    BossAttackResponse,
+    BossDamageRequest,
+    BossDamageResponse,
+    BossDefeatResponse,
+    BossStartRequest,
+    BossStartResponse,
+    BossStateType,
+)
+
+router = APIRouter(prefix="/api/v1/boss", tags=["boss"])
+
+
+@router.post("/start", response_model=BossStartResponse)
+async def start_boss_fight(body: BossStartRequest, request: Request):
+    """Initialize a new Corrupted Guardian boss fight."""
+    engine = request.app.state.boss_engine
+    return engine.start_fight(body)
+
+
+@router.post("/damage", response_model=BossDamageResponse)
+async def deal_damage(body: BossDamageRequest, request: Request):
+    """Apply player damage to the boss."""
+    engine = request.app.state.boss_engine
+    try:
+        return engine.apply_damage(body)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/next-attack", response_model=BossAttackResponse)
+async def get_next_attack(body: BossAttackRequest, request: Request):
+    """Request the boss to select and telegraph its next attack."""
+    engine = request.app.state.boss_engine
+    try:
+        return engine.select_attack(body)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/recovery")
+async def notify_recovery(request: Request):
+    """Notify the server that the boss has entered its recovery window."""
+    engine = request.app.state.boss_engine
+    engine.set_recovery()
+    state = engine.state
+    if state is None:
+        raise HTTPException(status_code=400, detail="Boss fight not started")
+    return {"boss_state": state, "message": "Boss is vulnerable!"}
+
+
+@router.post("/end-recovery")
+async def end_recovery(request: Request):
+    """Notify the server that the boss recovery window has ended."""
+    engine = request.app.state.boss_engine
+    engine.end_recovery()
+    state = engine.state
+    if state is None:
+        raise HTTPException(status_code=400, detail="Boss fight not started")
+    return {"boss_state": state, "message": "Boss recovers its guard."}
+
+
+@router.get("/loot", response_model=BossDefeatResponse)
+async def get_loot(request: Request):
+    """Generate and return loot after the boss is defeated."""
+    engine = request.app.state.boss_engine
+    state = engine.state
+    if state is None or state.ai_state != BossStateType.DEAD:
+        raise HTTPException(
+            status_code=400,
+            detail="Boss must be defeated before collecting loot",
+        )
+    return engine.generate_loot()
+
+
+@router.get("/state")
+async def get_boss_state(request: Request):
+    """Get the current boss fight state."""
+    engine = request.app.state.boss_engine
+    state = engine.state
+    if state is None:
+        raise HTTPException(
+            status_code=400, detail="No active boss fight"
+        )
+    return {"boss_state": state}

--- a/services/game-logic/app/main.py
+++ b/services/game-logic/app/main.py
@@ -8,10 +8,12 @@ from app.api.combat import router as combat_router
 from app.api.gacha import router as gacha_router
 from app.api.progression import router as progression_router
 from app.api.anomaly import router as anomaly_router
+from app.api.boss import router as boss_router
 from app.services.combat_engine import CombatEngine
 from app.services.gacha_system import GachaSystem
 from app.services.progression import ProgressionService
 from app.services.anomaly_detector import AnomalyDetector
+from app.services.boss_engine import BossEngine
 
 logging.basicConfig(level=settings.log_level)
 logger = logging.getLogger(__name__)
@@ -23,6 +25,7 @@ async def lifespan(app: FastAPI):
     app.state.gacha_system = GachaSystem(settings.gacha_pools_path)
     app.state.progression_service = ProgressionService()
     app.state.anomaly_detector = AnomalyDetector()
+    app.state.boss_engine = BossEngine()
     logger.info("Game logic services initialized")
     yield
 

--- a/services/game-logic/app/models/boss_schemas.py
+++ b/services/game-logic/app/models/boss_schemas.py
@@ -1,0 +1,249 @@
+"""Schemas for the Corrupted Guardian boss fight.
+
+Defines server-authoritative boss state, attack declarations,
+phase management, damage events, and loot results.
+"""
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from app.models.schemas import Element
+
+
+class BossPhase(str, Enum):
+    """Boss fight phases based on HP thresholds."""
+    PHASE_1 = "phase_1"  # 100%-50% HP
+    PHASE_2 = "phase_2"  # 50%-0% HP
+
+
+class BossAttackType(str, Enum):
+    """All attack types the Corrupted Guardian can use."""
+    GROUND_SLAM = "ground_slam"
+    SHADOW_BOLT = "shadow_bolt"
+    CORRUPTION_WAVE = "corruption_wave"  # Phase 2 only
+    SUMMON_MINIONS = "summon_minions"    # Phase 1 at 75% HP
+
+
+class BossStateType(str, Enum):
+    """Server-side boss AI states."""
+    IDLE = "idle"
+    TELEGRAPH = "telegraph"
+    ATTACK = "attack"
+    RECOVERY = "recovery"
+    PHASE_TRANSITION = "phase_transition"
+    ENRAGED = "enraged"
+    DEAD = "dead"
+
+
+class BossConfig(BaseModel):
+    """Static configuration for the Corrupted Guardian."""
+    name: str = "Corrupted Guardian"
+    max_hp: int = 2500
+    attack: int = 45
+    defense: int = 22
+    speed: float = 70.0
+    element: Element = Element.FIRE
+    detection_range: float = 800.0  # Arena-wide auto-aggro
+    melee_range: float = 120.0
+    ranged_range: float = 300.0
+    phase_2_threshold: float = 0.5  # 50% HP
+    minion_summon_threshold: float = 0.75  # 75% HP
+    enrage_timer_seconds: float = 180.0  # 3 minutes
+    vulnerability_duration_ms: float = 2000.0  # 2s recovery window
+    vulnerability_damage_mult: float = 1.5  # +50% damage during recovery
+    xp_reward: int = 500
+
+
+class BossAttackConfig(BaseModel):
+    """Timing and damage configuration for a single boss attack."""
+    attack_type: BossAttackType
+    telegraph_ms: float
+    active_ms: float
+    recovery_ms: float
+    cooldown_ms: float
+    damage: int
+    range_px: float
+    element: Element | None = None
+    aoe_radius: float = 0.0
+    notes: str = ""
+
+
+# Phase 1 attack configs
+GROUND_SLAM_P1 = BossAttackConfig(
+    attack_type=BossAttackType.GROUND_SLAM,
+    telegraph_ms=1500,
+    active_ms=500,
+    recovery_ms=2000,
+    cooldown_ms=3000,
+    damage=50,
+    range_px=200,
+    element=Element.FIRE,
+    aoe_radius=200,
+    notes="Telegraphed by glowing ground cracks. Dodgeable.",
+)
+
+SHADOW_BOLT_P1 = BossAttackConfig(
+    attack_type=BossAttackType.SHADOW_BOLT,
+    telegraph_ms=1500,
+    active_ms=300,
+    recovery_ms=2000,
+    cooldown_ms=3500,
+    damage=30,
+    range_px=350,
+    element=Element.SHADOW,
+    aoe_radius=60,
+    notes="Straight-line projectile, medium speed.",
+)
+
+SUMMON_MINIONS = BossAttackConfig(
+    attack_type=BossAttackType.SUMMON_MINIONS,
+    telegraph_ms=1500,
+    active_ms=500,
+    recovery_ms=2000,
+    cooldown_ms=15000,
+    damage=0,
+    range_px=0,
+    notes="Summons 2 shadow minions. One-time at 75% HP.",
+)
+
+# Phase 2 attack configs (faster telegraphs)
+GROUND_SLAM_P2 = BossAttackConfig(
+    attack_type=BossAttackType.GROUND_SLAM,
+    telegraph_ms=1000,
+    active_ms=400,
+    recovery_ms=2000,
+    cooldown_ms=2400,
+    damage=65,
+    range_px=220,
+    element=Element.FIRE,
+    aoe_radius=220,
+    notes="Faster telegraph, larger AoE, more damage.",
+)
+
+SHADOW_BOLT_P2 = BossAttackConfig(
+    attack_type=BossAttackType.SHADOW_BOLT,
+    telegraph_ms=1000,
+    active_ms=200,
+    recovery_ms=2000,
+    cooldown_ms=2800,
+    damage=40,
+    range_px=350,
+    element=Element.SHADOW,
+    aoe_radius=60,
+    notes="Faster telegraph, more damage.",
+)
+
+CORRUPTION_WAVE = BossAttackConfig(
+    attack_type=BossAttackType.CORRUPTION_WAVE,
+    telegraph_ms=1000,
+    active_ms=800,
+    recovery_ms=2000,
+    cooldown_ms=5000,
+    damage=45,
+    range_px=400,
+    element=Element.VOID,
+    aoe_radius=400,
+    notes="AoE ring. Must dodge through it.",
+)
+
+# Phase attack tables
+PHASE_1_ATTACKS = [GROUND_SLAM_P1, SHADOW_BOLT_P1]
+PHASE_2_ATTACKS = [GROUND_SLAM_P2, SHADOW_BOLT_P2, CORRUPTION_WAVE]
+
+
+class BossState(BaseModel):
+    """Server-authoritative snapshot of the boss fight state."""
+    boss_id: str = "corrupted_guardian"
+    current_hp: int
+    max_hp: int = 2500
+    phase: BossPhase = BossPhase.PHASE_1
+    ai_state: BossStateType = BossStateType.IDLE
+    current_attack: BossAttackType | None = None
+    is_vulnerable: bool = False
+    is_enraged: bool = False
+    enrage_timer_remaining: float = 180.0
+    minions_summoned: bool = False
+    minions_alive: int = 0
+    phase_transitioned: bool = False
+    fight_started: bool = False
+
+
+class BossStartRequest(BaseModel):
+    """Request to initiate the boss fight."""
+    player_level: int = Field(ge=1)
+    player_stats: dict = Field(
+        description="Player combat stats (attack, defense, critical_rate, etc.)"
+    )
+
+
+class BossStartResponse(BaseModel):
+    """Response after starting the boss fight."""
+    boss_state: BossState
+    arena_config: dict = Field(
+        default_factory=lambda: {
+            "diameter": 800,
+            "pillars": 4,
+            "pillar_hp": 200,
+        }
+    )
+    message: str = "The Corrupted Guardian awakens!"
+
+
+class BossDamageRequest(BaseModel):
+    """Request to deal damage to the boss."""
+    damage: int = Field(gt=0)
+    element: Element | None = None
+    is_critical: bool = False
+    player_position: dict = Field(
+        default_factory=lambda: {"x": 0, "y": 0},
+        description="Player position for AoE/range checks.",
+    )
+
+
+class BossDamageResponse(BaseModel):
+    """Response after dealing damage to the boss."""
+    actual_damage: int
+    boss_state: BossState
+    phase_changed: bool = False
+    new_phase: BossPhase | None = None
+    vulnerability_bonus: bool = False
+    message: str = ""
+
+
+class BossAttackRequest(BaseModel):
+    """Request the boss to select and execute its next attack."""
+    player_position: dict = Field(
+        description="Current player position {x, y}."
+    )
+    elapsed_ms: float = Field(
+        description="Time since last boss action in ms."
+    )
+
+
+class BossAttackResponse(BaseModel):
+    """Response with the boss's chosen attack."""
+    attack: BossAttackConfig
+    boss_state: BossState
+    telegraph_position: dict = Field(
+        default_factory=lambda: {"x": 0, "y": 0},
+        description="Position where the attack will land.",
+    )
+    message: str = ""
+
+
+class BossLootItem(BaseModel):
+    """A single item from the boss loot table."""
+    id: str
+    name: str
+    rarity: str = Field(pattern=r"^(common|uncommon|rare|epic|legendary)$")
+    drop_rate: float
+
+
+class BossDefeatResponse(BaseModel):
+    """Response when the boss is defeated."""
+    xp_reward: int
+    loot: list[BossLootItem]
+    fight_duration_seconds: float
+    total_damage_dealt: int
+    message: str = "The Corrupted Guardian has fallen!"

--- a/services/game-logic/app/services/boss_engine.py
+++ b/services/game-logic/app/services/boss_engine.py
@@ -1,0 +1,339 @@
+"""Server-side boss fight engine for the Corrupted Guardian.
+
+Manages phase transitions, attack selection, damage calculations,
+vulnerability windows, enrage timer, and loot generation.
+"""
+
+import random
+import time
+
+from app.models.boss_schemas import (
+    BossAttackConfig,
+    BossAttackRequest,
+    BossAttackResponse,
+    BossAttackType,
+    BossConfig,
+    BossDamageRequest,
+    BossDamageResponse,
+    BossDefeatResponse,
+    BossLootItem,
+    BossPhase,
+    BossStartRequest,
+    BossStartResponse,
+    BossState,
+    BossStateType,
+    PHASE_1_ATTACKS,
+    PHASE_2_ATTACKS,
+    SUMMON_MINIONS,
+)
+from app.models.schemas import Element
+
+
+# Loot table for the Corrupted Guardian
+BOSS_LOOT_TABLE: list[BossLootItem] = [
+    BossLootItem(
+        id="guardians_molten_core",
+        name="Guardian's Molten Core",
+        rarity="legendary",
+        drop_rate=1.0,  # Guaranteed
+    ),
+    BossLootItem(
+        id="corrupted_void_shard",
+        name="Corrupted Void Shard",
+        rarity="uncommon",
+        drop_rate=0.4,
+    ),
+    BossLootItem(
+        id="infernal_guardian_greaves",
+        name="Infernal Guardian Greaves",
+        rarity="rare",
+        drop_rate=0.15,
+    ),
+    BossLootItem(
+        id="flame_of_the_fallen",
+        name="Flame of the Fallen",
+        rarity="rare",
+        drop_rate=0.12,
+    ),
+    BossLootItem(
+        id="void_touched_aegis",
+        name="Void-Touched Aegis",
+        rarity="epic",
+        drop_rate=0.05,
+    ),
+    BossLootItem(
+        id="guardians_ember_crown",
+        name="Guardian's Ember Crown",
+        rarity="epic",
+        drop_rate=0.03,
+    ),
+]
+
+
+class BossEngine:
+    """Server-side engine for the Corrupted Guardian boss fight.
+
+    This engine is authoritative for:
+    - Phase management (HP thresholds trigger phase transitions)
+    - Attack selection (weighted random from phase attack table)
+    - Damage calculation (defense, vulnerability bonus, element resist)
+    - Enrage timer (3 minutes, then instant kill)
+    - Loot generation (guaranteed legendary + RNG rolls)
+    """
+
+    def __init__(self) -> None:
+        self.config = BossConfig()
+        self._state: BossState | None = None
+        self._fight_start_time: float = 0.0
+        self._total_damage_dealt: int = 0
+        self._last_attack_time: float = 0.0
+        self._attack_cooldowns: dict[BossAttackType, float] = {}
+
+    @property
+    def state(self) -> BossState | None:
+        return self._state
+
+    def start_fight(self, request: BossStartRequest) -> BossStartResponse:
+        """Initialize a new boss fight session."""
+        self._state = BossState(
+            current_hp=self.config.max_hp,
+            max_hp=self.config.max_hp,
+            fight_started=True,
+        )
+        self._fight_start_time = time.monotonic()
+        self._total_damage_dealt = 0
+        self._attack_cooldowns.clear()
+
+        return BossStartResponse(boss_state=self._state)
+
+    def apply_damage(self, request: BossDamageRequest) -> BossDamageResponse:
+        """Apply player damage to the boss, handling phase transitions."""
+        if self._state is None:
+            raise ValueError("Boss fight has not been started")
+
+        if self._state.ai_state == BossStateType.DEAD:
+            raise ValueError("Boss is already dead")
+
+        # Calculate actual damage
+        actual_damage = self._calculate_incoming_damage(
+            request.damage, request.element
+        )
+
+        # Vulnerability bonus during recovery window
+        vulnerability_bonus = False
+        if self._state.is_vulnerable:
+            actual_damage = int(
+                actual_damage * self.config.vulnerability_damage_mult
+            )
+            vulnerability_bonus = True
+
+        # Apply damage
+        self._state.current_hp = max(0, self._state.current_hp - actual_damage)
+        self._total_damage_dealt += actual_damage
+
+        # Check phase transition
+        phase_changed = False
+        new_phase = None
+        hp_ratio = self._state.current_hp / self._state.max_hp
+
+        if (
+            self._state.phase == BossPhase.PHASE_1
+            and hp_ratio <= self.config.phase_2_threshold
+            and not self._state.phase_transitioned
+        ):
+            self._state.phase = BossPhase.PHASE_2
+            self._state.phase_transitioned = True
+            self._state.ai_state = BossStateType.PHASE_TRANSITION
+            self._state.is_enraged = True
+            phase_changed = True
+            new_phase = BossPhase.PHASE_2
+            # Reset cooldowns for phase 2
+            self._attack_cooldowns.clear()
+
+        # Check death
+        message = ""
+        if self._state.current_hp <= 0:
+            self._state.ai_state = BossStateType.DEAD
+            message = "The Corrupted Guardian staggers and falls!"
+        elif phase_changed:
+            message = (
+                "The Guardian roars! Corruption surges through its body. "
+                "Rage mode activated!"
+            )
+        elif vulnerability_bonus:
+            message = "Vulnerability exploited! +50% damage!"
+
+        return BossDamageResponse(
+            actual_damage=actual_damage,
+            boss_state=self._state,
+            phase_changed=phase_changed,
+            new_phase=new_phase,
+            vulnerability_bonus=vulnerability_bonus,
+            message=message,
+        )
+
+    def select_attack(
+        self, request: BossAttackRequest
+    ) -> BossAttackResponse:
+        """Select the boss's next attack based on phase and cooldowns."""
+        if self._state is None:
+            raise ValueError("Boss fight has not been started")
+
+        if self._state.ai_state == BossStateType.DEAD:
+            raise ValueError("Boss is already dead")
+
+        # Update enrage timer
+        elapsed_total = time.monotonic() - self._fight_start_time
+        self._state.enrage_timer_remaining = max(
+            0.0, self.config.enrage_timer_seconds - elapsed_total
+        )
+
+        # Check enrage
+        if self._state.enrage_timer_remaining <= 0:
+            self._state.is_enraged = True
+            self._state.ai_state = BossStateType.ENRAGED
+
+        # Check for minion summon at 75% HP (one-time)
+        hp_ratio = self._state.current_hp / self._state.max_hp
+        if (
+            not self._state.minions_summoned
+            and hp_ratio <= self.config.minion_summon_threshold
+            and self._state.phase == BossPhase.PHASE_1
+        ):
+            self._state.minions_summoned = True
+            self._state.minions_alive = 2
+            self._state.ai_state = BossStateType.TELEGRAPH
+            self._state.current_attack = BossAttackType.SUMMON_MINIONS
+            return BossAttackResponse(
+                attack=SUMMON_MINIONS,
+                boss_state=self._state,
+                telegraph_position=request.player_position,
+                message="The Guardian raises its arms! Shadow portals appear!",
+            )
+
+        # Select from phase attack table
+        attacks = self._get_available_attacks(request.elapsed_ms)
+        if not attacks:
+            # All on cooldown -- idle
+            self._state.ai_state = BossStateType.IDLE
+            self._state.current_attack = None
+            return BossAttackResponse(
+                attack=self._get_phase_attacks()[0],  # Fallback
+                boss_state=self._state,
+                telegraph_position=request.player_position,
+                message="The Guardian watches...",
+            )
+
+        # Weighted random selection
+        chosen = random.choice(attacks)
+
+        # Update state
+        self._state.ai_state = BossStateType.TELEGRAPH
+        self._state.current_attack = chosen.attack_type
+
+        # Set cooldown
+        self._attack_cooldowns[chosen.attack_type] = (
+            time.monotonic() + chosen.cooldown_ms / 1000.0
+        )
+
+        # Calculate telegraph position (target player position)
+        telegraph_pos = dict(request.player_position)
+
+        message = self._get_telegraph_message(chosen.attack_type)
+
+        return BossAttackResponse(
+            attack=chosen,
+            boss_state=self._state,
+            telegraph_position=telegraph_pos,
+            message=message,
+        )
+
+    def set_recovery(self) -> None:
+        """Transition the boss to recovery state (vulnerability window)."""
+        if self._state is not None:
+            self._state.ai_state = BossStateType.RECOVERY
+            self._state.is_vulnerable = True
+            self._state.current_attack = None
+
+    def end_recovery(self) -> None:
+        """End the recovery/vulnerability window."""
+        if self._state is not None:
+            self._state.is_vulnerable = False
+            self._state.ai_state = BossStateType.IDLE
+
+    def generate_loot(self) -> BossDefeatResponse:
+        """Generate loot drops on boss defeat."""
+        fight_duration = time.monotonic() - self._fight_start_time
+
+        # Roll loot
+        drops: list[BossLootItem] = []
+        for item in BOSS_LOOT_TABLE:
+            if item.drop_rate >= 1.0 or random.random() < item.drop_rate:
+                drops.append(item)
+
+        return BossDefeatResponse(
+            xp_reward=self.config.xp_reward,
+            loot=drops,
+            fight_duration_seconds=round(fight_duration, 1),
+            total_damage_dealt=self._total_damage_dealt,
+        )
+
+    def _calculate_incoming_damage(
+        self, raw_damage: int, element: Element | None
+    ) -> int:
+        """Apply boss defense and elemental resistance to incoming damage."""
+        # Apply defense
+        damage_after_def = max(1, raw_damage - self.config.defense)
+
+        # Elemental resistance (simplified from GDD for 2-phase version)
+        if element == Element.FIRE:
+            # Boss is immune to fire
+            return 0
+        elif element == Element.SHADOW:
+            # Boss is resistant to shadow
+            damage_after_def = int(damage_after_def * 0.8)
+        elif element == Element.VOID:
+            if self._state and self._state.phase == BossPhase.PHASE_2:
+                # Immune to void in phase 2
+                return 0
+            else:
+                damage_after_def = int(damage_after_def * 0.5)
+
+        return max(1, damage_after_def)
+
+    def _get_phase_attacks(self) -> list[BossAttackConfig]:
+        """Return the attack table for the current phase."""
+        if self._state and self._state.phase == BossPhase.PHASE_2:
+            return PHASE_2_ATTACKS
+        return PHASE_1_ATTACKS
+
+    def _get_available_attacks(
+        self, elapsed_ms: float
+    ) -> list[BossAttackConfig]:
+        """Return attacks that are off cooldown."""
+        now = time.monotonic()
+        attacks = self._get_phase_attacks()
+        available = []
+        for atk in attacks:
+            cd = self._attack_cooldowns.get(atk.attack_type, 0.0)
+            if now >= cd:
+                available.append(atk)
+        return available
+
+    def _get_telegraph_message(self, attack_type: BossAttackType) -> str:
+        """Return a descriptive message for the attack telegraph."""
+        messages = {
+            BossAttackType.GROUND_SLAM: (
+                "The Guardian raises its fists! Ground cracks glow beneath you!"
+            ),
+            BossAttackType.SHADOW_BOLT: (
+                "Dark energy gathers in the Guardian's hand!"
+            ),
+            BossAttackType.CORRUPTION_WAVE: (
+                "The Guardian channels corruption! A wave of darkness expands!"
+            ),
+            BossAttackType.SUMMON_MINIONS: (
+                "Shadow portals tear open!"
+            ),
+        }
+        return messages.get(attack_type, "The Guardian prepares to attack!")

--- a/services/game-logic/tests/test_boss.py
+++ b/services/game-logic/tests/test_boss.py
@@ -1,0 +1,387 @@
+"""Tests for the Corrupted Guardian boss fight.
+
+Covers: boss engine unit tests (phase transitions, damage calc, loot,
+vulnerability, enrage, elemental resistance) and API endpoint integration tests.
+"""
+
+import pytest
+
+from app.models.boss_schemas import (
+    BossAttackType,
+    BossDamageRequest,
+    BossPhase,
+    BossStartRequest,
+    BossStateType,
+)
+from app.models.schemas import Element
+from app.services.boss_engine import BossEngine
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — BossEngine
+# ---------------------------------------------------------------------------
+
+
+class TestBossEngineStartFight:
+    """Test boss fight initialization."""
+
+    def setup_method(self):
+        self.engine = BossEngine()
+
+    def test_start_creates_boss_state(self):
+        req = BossStartRequest(
+            player_level=10,
+            player_stats={"attack": 50, "defense": 20, "critical_rate": 0.1},
+        )
+        resp = self.engine.start_fight(req)
+        assert resp.boss_state.current_hp == 2500
+        assert resp.boss_state.max_hp == 2500
+        assert resp.boss_state.phase == BossPhase.PHASE_1
+        assert resp.boss_state.fight_started is True
+
+    def test_start_returns_arena_config(self):
+        req = BossStartRequest(
+            player_level=10, player_stats={"attack": 50}
+        )
+        resp = self.engine.start_fight(req)
+        assert resp.arena_config["diameter"] == 800
+        assert resp.arena_config["pillars"] == 4
+
+
+class TestBossEngineDamage:
+    """Test damage application and phase transitions."""
+
+    def setup_method(self):
+        self.engine = BossEngine()
+        self.engine.start_fight(
+            BossStartRequest(
+                player_level=10,
+                player_stats={"attack": 50, "defense": 20},
+            )
+        )
+
+    def test_damage_reduces_hp(self):
+        req = BossDamageRequest(damage=100)
+        resp = self.engine.apply_damage(req)
+        # 100 - 22 defense = 78 actual damage
+        assert resp.actual_damage == 78
+        assert resp.boss_state.current_hp == 2500 - 78
+
+    def test_fire_damage_is_immune(self):
+        req = BossDamageRequest(damage=100, element=Element.FIRE)
+        resp = self.engine.apply_damage(req)
+        assert resp.actual_damage == 0
+        assert resp.boss_state.current_hp == 2500
+
+    def test_shadow_damage_is_resisted(self):
+        req = BossDamageRequest(damage=100, element=Element.SHADOW)
+        resp = self.engine.apply_damage(req)
+        # (100 - 22) * 0.8 = 62.4 -> 62
+        assert resp.actual_damage == 62
+
+    def test_void_damage_half_resisted_phase_1(self):
+        req = BossDamageRequest(damage=100, element=Element.VOID)
+        resp = self.engine.apply_damage(req)
+        # (100 - 22) * 0.5 = 39
+        assert resp.actual_damage == 39
+
+    def test_blood_damage_normal(self):
+        req = BossDamageRequest(damage=100, element=Element.BLOOD)
+        resp = self.engine.apply_damage(req)
+        # 100 - 22 = 78 (no element modifier for blood)
+        assert resp.actual_damage == 78
+
+    def test_minimum_damage_is_one(self):
+        req = BossDamageRequest(damage=1)
+        resp = self.engine.apply_damage(req)
+        assert resp.actual_damage == 1
+
+    def test_phase_transition_at_50_percent(self):
+        # Deal enough damage to cross 50% threshold (2500 * 0.5 = 1250)
+        # Need 1250 HP of actual damage. With 22 defense: need many hits.
+        # Set HP directly for test clarity.
+        self.engine._state.current_hp = 1300  # type: ignore[union-attr]
+        req = BossDamageRequest(damage=100)
+        resp = self.engine.apply_damage(req)
+        # 100 - 22 = 78, 1300 - 78 = 1222 which is < 1250
+        assert resp.phase_changed is True
+        assert resp.new_phase == BossPhase.PHASE_2
+        assert resp.boss_state.is_enraged is True
+
+    def test_phase_transition_only_happens_once(self):
+        self.engine._state.current_hp = 1300  # type: ignore[union-attr]
+        req = BossDamageRequest(damage=100)
+        self.engine.apply_damage(req)  # Triggers phase transition
+        # Hit again
+        resp = self.engine.apply_damage(req)
+        assert resp.phase_changed is False
+
+    def test_void_immune_in_phase_2(self):
+        # Force to phase 2
+        self.engine._state.phase = BossPhase.PHASE_2  # type: ignore[union-attr]
+        self.engine._state.phase_transitioned = True  # type: ignore[union-attr]
+        req = BossDamageRequest(damage=100, element=Element.VOID)
+        resp = self.engine.apply_damage(req)
+        assert resp.actual_damage == 0
+
+    def test_boss_death(self):
+        self.engine._state.current_hp = 50  # type: ignore[union-attr]
+        self.engine._state.phase = BossPhase.PHASE_2  # type: ignore[union-attr]
+        self.engine._state.phase_transitioned = True  # type: ignore[union-attr]
+        req = BossDamageRequest(damage=200)
+        resp = self.engine.apply_damage(req)
+        assert resp.boss_state.current_hp == 0
+        assert resp.boss_state.ai_state == BossStateType.DEAD
+
+
+class TestBossEngineVulnerability:
+    """Test the vulnerability/recovery window mechanic."""
+
+    def setup_method(self):
+        self.engine = BossEngine()
+        self.engine.start_fight(
+            BossStartRequest(
+                player_level=10,
+                player_stats={"attack": 50, "defense": 20},
+            )
+        )
+
+    def test_vulnerability_window_bonus_damage(self):
+        self.engine.set_recovery()
+        assert self.engine.state.is_vulnerable is True  # type: ignore[union-attr]
+
+        req = BossDamageRequest(damage=100)
+        resp = self.engine.apply_damage(req)
+        # (100 - 22) * 1.5 = 117
+        assert resp.actual_damage == 117
+        assert resp.vulnerability_bonus is True
+
+    def test_end_recovery_clears_vulnerability(self):
+        self.engine.set_recovery()
+        self.engine.end_recovery()
+        assert self.engine.state.is_vulnerable is False  # type: ignore[union-attr]
+        assert self.engine.state.ai_state == BossStateType.IDLE  # type: ignore[union-attr]
+
+
+class TestBossEngineAttackSelection:
+    """Test boss attack selection logic."""
+
+    def setup_method(self):
+        self.engine = BossEngine()
+        self.engine.start_fight(
+            BossStartRequest(
+                player_level=10,
+                player_stats={"attack": 50, "defense": 20},
+            )
+        )
+
+    def test_selects_attack_from_phase_1(self):
+        from app.models.boss_schemas import BossAttackRequest
+
+        req = BossAttackRequest(
+            player_position={"x": 400, "y": 400},
+            elapsed_ms=5000,
+        )
+        resp = self.engine.select_attack(req)
+        assert resp.attack.attack_type in [
+            BossAttackType.GROUND_SLAM,
+            BossAttackType.SHADOW_BOLT,
+        ]
+        assert resp.boss_state.ai_state == BossStateType.TELEGRAPH
+
+    def test_minion_summon_at_75_percent(self):
+        from app.models.boss_schemas import BossAttackRequest
+
+        self.engine._state.current_hp = int(2500 * 0.74)  # type: ignore[union-attr]
+        req = BossAttackRequest(
+            player_position={"x": 400, "y": 400},
+            elapsed_ms=5000,
+        )
+        resp = self.engine.select_attack(req)
+        assert resp.attack.attack_type == BossAttackType.SUMMON_MINIONS
+        assert resp.boss_state.minions_summoned is True
+        assert resp.boss_state.minions_alive == 2
+
+    def test_minion_summon_only_once(self):
+        from app.models.boss_schemas import BossAttackRequest
+
+        self.engine._state.current_hp = int(2500 * 0.74)  # type: ignore[union-attr]
+        req = BossAttackRequest(
+            player_position={"x": 400, "y": 400},
+            elapsed_ms=5000,
+        )
+        self.engine.select_attack(req)
+        # Second call should not summon again
+        resp = self.engine.select_attack(req)
+        assert resp.attack.attack_type != BossAttackType.SUMMON_MINIONS
+
+
+class TestBossEngineLoot:
+    """Test loot generation on boss defeat."""
+
+    def setup_method(self):
+        self.engine = BossEngine()
+        self.engine.start_fight(
+            BossStartRequest(
+                player_level=10,
+                player_stats={"attack": 50, "defense": 20},
+            )
+        )
+        # Kill the boss
+        self.engine._state.current_hp = 0  # type: ignore[union-attr]
+        self.engine._state.ai_state = BossStateType.DEAD  # type: ignore[union-attr]
+
+    def test_loot_contains_guaranteed_legendary(self):
+        resp = self.engine.generate_loot()
+        legendary_items = [
+            item for item in resp.loot if item.rarity == "legendary"
+        ]
+        assert len(legendary_items) >= 1
+        assert any(
+            item.id == "guardians_molten_core" for item in legendary_items
+        )
+
+    def test_loot_contains_xp_reward(self):
+        resp = self.engine.generate_loot()
+        assert resp.xp_reward == 500
+
+    def test_loot_total_damage_tracked(self):
+        resp = self.engine.generate_loot()
+        assert resp.total_damage_dealt >= 0
+
+
+class TestBossEngineErrorHandling:
+    """Test error handling edge cases."""
+
+    def test_damage_before_start_raises(self):
+        engine = BossEngine()
+        req = BossDamageRequest(damage=100)
+        with pytest.raises(ValueError, match="not been started"):
+            engine.apply_damage(req)
+
+    def test_damage_after_death_raises(self):
+        engine = BossEngine()
+        engine.start_fight(
+            BossStartRequest(
+                player_level=10,
+                player_stats={"attack": 50},
+            )
+        )
+        engine._state.ai_state = BossStateType.DEAD  # type: ignore[union-attr]
+        req = BossDamageRequest(damage=100)
+        with pytest.raises(ValueError, match="already dead"):
+            engine.apply_damage(req)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — API endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_boss_start_endpoint(client):
+    payload = {
+        "player_level": 10,
+        "player_stats": {"attack": 50, "defense": 20, "critical_rate": 0.1},
+    }
+    response = await client.post("/api/v1/boss/start", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["boss_state"]["current_hp"] == 2500
+    assert data["boss_state"]["phase"] == "phase_1"
+    assert data["arena_config"]["diameter"] == 800
+
+
+@pytest.mark.anyio
+async def test_boss_damage_endpoint(client):
+    # Start fight first
+    await client.post(
+        "/api/v1/boss/start",
+        json={"player_level": 10, "player_stats": {"attack": 50}},
+    )
+    # Deal damage
+    payload = {"damage": 100, "element": None, "is_critical": False}
+    response = await client.post("/api/v1/boss/damage", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["actual_damage"] == 78  # 100 - 22 defense
+    assert data["boss_state"]["current_hp"] == 2500 - 78
+
+
+@pytest.mark.anyio
+async def test_boss_fire_immune_endpoint(client):
+    await client.post(
+        "/api/v1/boss/start",
+        json={"player_level": 10, "player_stats": {"attack": 50}},
+    )
+    payload = {"damage": 100, "element": "fire"}
+    response = await client.post("/api/v1/boss/damage", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["actual_damage"] == 0
+
+
+@pytest.mark.anyio
+async def test_boss_next_attack_endpoint(client):
+    await client.post(
+        "/api/v1/boss/start",
+        json={"player_level": 10, "player_stats": {"attack": 50}},
+    )
+    payload = {"player_position": {"x": 400, "y": 400}, "elapsed_ms": 5000}
+    response = await client.post("/api/v1/boss/next-attack", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["attack"]["attack_type"] in ["ground_slam", "shadow_bolt"]
+
+
+@pytest.mark.anyio
+async def test_boss_recovery_endpoint(client):
+    await client.post(
+        "/api/v1/boss/start",
+        json={"player_level": 10, "player_stats": {"attack": 50}},
+    )
+    response = await client.post("/api/v1/boss/recovery")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["boss_state"]["is_vulnerable"] is True
+
+
+@pytest.mark.anyio
+async def test_boss_end_recovery_endpoint(client):
+    await client.post(
+        "/api/v1/boss/start",
+        json={"player_level": 10, "player_stats": {"attack": 50}},
+    )
+    await client.post("/api/v1/boss/recovery")
+    response = await client.post("/api/v1/boss/end-recovery")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["boss_state"]["is_vulnerable"] is False
+
+
+@pytest.mark.anyio
+async def test_boss_loot_requires_defeat(client):
+    await client.post(
+        "/api/v1/boss/start",
+        json={"player_level": 10, "player_stats": {"attack": 50}},
+    )
+    response = await client.get("/api/v1/boss/loot")
+    assert response.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_boss_state_endpoint(client):
+    await client.post(
+        "/api/v1/boss/start",
+        json={"player_level": 10, "player_stats": {"attack": 50}},
+    )
+    response = await client.get("/api/v1/boss/state")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["boss_state"]["boss_id"] == "corrupted_guardian"
+
+
+@pytest.mark.anyio
+async def test_boss_state_before_start(client):
+    response = await client.get("/api/v1/boss/state")
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- Add `CorruptedGuardian` boss entity with BossAI state machine and 3 attack patterns (CorruptionWave, GroundSlam, ShadowBolt)
- Add backend boss engine with 2-phase transitions, Pydantic schemas, and API routes
- Add boss router integration in `main.py` and unit tests (387 lines)
- Client-side: BossConfig, BossAI, and full attack implementations (1,215 lines TS)

Closes #16

## Test plan
- [ ] Run `pytest services/game-logic/tests/test_boss.py` — all tests pass
- [ ] Verify boss phase transitions (phase 1 → phase 2 at health threshold)
- [ ] Test each attack pattern renders correctly in Phaser client
- [ ] Confirm API routes `/boss/*` respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)