### PR TITLE
feat(talent-tree): add Talent Tree UI component and stats calculator (#28)

### DIFF
--- a/client/src/components/TalentTree.tsx
+++ b/client/src/components/TalentTree.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const TalentTree: React.FC = () => {
+    return (
+        <div>
+            <h1>Talent Tree</h1>
+            {/* Talent tree UI will go here */}
+        </div>
+    );
+};
+
+export default TalentTree;

--- a/services/game-logic/app/services/stats_calculator.py
+++ b/services/game-logic/app/services/stats_calculator.py
@@ -1,0 +1,12 @@
+def apply_talents(base_stats: dict, talents: list[str]) -> dict:
+    stats = base_stats.copy()
+    talent_bonuses = {
+        "shadow_mastery": {"shadow_dmg_multiplier": 1.15},
+        "critical_edge": {"crit_rate": base_stats.get("crit_rate", 0) + 0.05},
+        "iron_will": {"max_hp": base_stats.get("max_hp", 0) + 50},
+    }
+    for talent in talents:
+        if talent in talent_bonuses:
+            for stat, value in talent_bonuses[talent].items():
+                stats[stat] = value
+    return stats


### PR DESCRIPTION
This PR adds the initial files for the Talent Tree meta-progression system, as specified in sub-issue #8.2.

- : A placeholder React component for the UI.
- : A service to apply talent bonuses to player stats.

**Parent Issue:** #28