### PR TITLE
feat(battle-pass): add purchase_battle_pass RPC function (#30)

### DIFF
--- a/nakama/src/main.ts
+++ b/nakama/src/main.ts
@@ -37,3 +37,33 @@ const rpcCreateClan: nkruntime.RpcFunction = function (
 
     return JSON.stringify({ groupId });
 };
+
+const rpcPurchaseBattlePass: nkruntime.RpcFunction = function (
+    ctx: nkruntime.Context,
+    logger: nkruntime.Logger,
+    nk: nkruntime.Nakama,
+    payload: string
+): string {
+    const { tier } = JSON.parse(payload);
+
+    // In a real implementation, this would integrate with the payment service
+    // and Stripe to verify the purchase.
+
+    const battlePass = {
+        level: 1,
+        premium: tier === 'premium',
+    };
+
+    nk.storageWrite([
+        {
+            collection: 'player_data',
+            key: 'battle_pass',
+            userId: ctx.userId,
+            value: battlePass,
+            permissionRead: 1,
+            permissionWrite: 0,
+        },
+    ]);
+
+    return JSON.stringify({ success: true });
+};


### PR DESCRIPTION
This PR adds the initial  RPC function for the Battle Pass system, as specified in sub-issue #9.2.

**Parent Issue:** #30