### PR TITLE
feat(load-testing): add k6 script for basic load testing (#31)

### DIFF
--- a/tests/load/k6.js
+++ b/tests/load/k6.js
@@ -1,0 +1,16 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 20 },
+    { duration: '1m30s', target: 10 },
+    { duration: '20s', target: 0 },
+  ],
+};
+
+export default function () {
+  const res = http.get('https://umbra-client.fly.dev');
+  check(res, { 'status was 200': (r) => r.status == 200 });
+  sleep(1);
+}


### PR DESCRIPTION
This PR adds a basic k6 script for load testing the client, as specified in sub-issue #10.1.

**Parent Issue:** #31