### PR TITLE
feat: add Fly.io provisioning and deployment scripts (#7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
+# =============================================================================
+# Umbra Platform — Environment Variables
+# Copy to .env and fill in your values: cp .env.example .env
+# =============================================================================
+
 # === AI Director ===
 OPENAI_API_KEY=sk-...
 ANTHROPIC_API_KEY=sk-ant-...
@@ -13,6 +18,7 @@ BATTLEPASS_SEASON_WEEKS=10
 
 # === Nakama ===
 NAKAMA_SERVER_KEY=defaultserverkey
+NAKAMA_HTTP_URL=http://localhost:7350
 
 # === Shared ===
 REDIS_URL=redis://redis:6379/0
@@ -21,3 +27,10 @@ LOG_LEVEL=INFO
 # === Celery ===
 CELERY_BROKER_URL=redis://redis:6379/1
 CELERY_RESULT_BACKEND=redis://redis:6379/1
+
+# === Client ===
+VITE_API_URL=http://localhost:8080
+
+# === Fly.io (production only — set via flyctl secrets) ===
+# DATABASE_URL is auto-set by flyctl postgres attach
+# REDIS_URL is set from flyctl redis create output

--- a/scripts/fly-deploy.sh
+++ b/scripts/fly-deploy.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Deploy all Umbra services to Fly.io in correct order.
+# Stateless services first, then services requiring migrations.
+#
+# Usage: ./scripts/fly-deploy.sh [--skip-health]
+
+set -euo pipefail
+
+SKIP_HEALTH=${1:-""}
+DEPLOY_FAILED=0
+
+deploy_service() {
+  local name=$1
+  local dir=$2
+  echo ""
+  echo "=== Deploying $name ==="
+  if (cd "$dir" && flyctl deploy --now 2>&1); then
+    echo "[OK] $name deployed successfully"
+  else
+    echo "[FAIL] $name deployment failed!"
+    DEPLOY_FAILED=1
+    return 1
+  fi
+}
+
+health_check() {
+  local name=$1
+  local url=$2
+  echo -n "  $name: "
+  if curl -sf "$url" -o /dev/null --max-time 10; then
+    echo "OK"
+  else
+    echo "FAIL"
+    return 1
+  fi
+}
+
+echo "=== Fly.io Deployment — Umbra Platform ==="
+echo "Deploying to region: cdg (Paris)"
+
+# Phase 1: Stateless services (parallel-safe but sequential for clarity)
+deploy_service "umbra-client" "client"
+deploy_service "umbra-game-logic" "services/game-logic"
+deploy_service "umbra-ai-director" "services/ai-director"
+
+# Phase 2: Services requiring database migrations
+deploy_service "umbra-payment" "services/payment"
+
+# Phase 3: Health checks
+if [ "$SKIP_HEALTH" != "--skip-health" ]; then
+  echo ""
+  echo "=== Health Checks ==="
+  sleep 5  # Wait for services to stabilize
+  health_check "Client" "https://umbra-client.fly.dev/"
+  health_check "Game Logic" "https://umbra-game-logic.fly.dev/health"
+  health_check "AI Director" "https://umbra-ai-director.fly.dev/health"
+  health_check "Payment" "https://umbra-payment.fly.dev/health"
+fi
+
+echo ""
+if [ $DEPLOY_FAILED -eq 0 ]; then
+  echo "=== All deployments successful ==="
+else
+  echo "=== Some deployments failed — check logs above ==="
+  echo "  Rollback: flyctl releases -a <app-name> && flyctl deploy -a <app-name> --image <previous-image>"
+  exit 1
+fi

--- a/scripts/fly-setup.sh
+++ b/scripts/fly-setup.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Provisions managed Postgres and Redis on Fly.io and configures secrets.
+# Run once after creating apps with: flyctl apps create umbra-{client,game-logic,ai-director,payment}
+#
+# Prerequisites: flyctl authenticated (flyctl auth login)
+# Usage: ./scripts/fly-setup.sh
+
+set -euo pipefail
+
+echo "=== Fly.io Umbra Platform Setup ==="
+
+# 1. Create managed Postgres for payment service
+echo ""
+echo "--- Creating Postgres cluster ---"
+flyctl postgres create \
+  --name umbra-postgres \
+  --region cdg \
+  --vm-size shared-cpu-1x \
+  --initial-cluster-size 1 \
+  --volume-size 1 \
+  || echo "Postgres cluster may already exist, continuing..."
+
+# 2. Attach Postgres to payment app (auto-sets DATABASE_URL secret)
+echo ""
+echo "--- Attaching Postgres to umbra-payment ---"
+flyctl postgres attach umbra-postgres --app umbra-payment \
+  || echo "Already attached or error, continuing..."
+
+# 3. Create Upstash Redis for AI Director and Game Logic
+echo ""
+echo "--- Creating Redis (Upstash) ---"
+REDIS_OUTPUT=$(flyctl redis create \
+  --name umbra-redis \
+  --region cdg \
+  --plan free \
+  --no-replicas \
+  2>&1) || echo "Redis may already exist, continuing..."
+echo "$REDIS_OUTPUT"
+
+# Extract Redis URL if available
+REDIS_URL=$(echo "$REDIS_OUTPUT" | grep -oP 'redis://\S+' || echo "")
+if [ -z "$REDIS_URL" ]; then
+  echo "WARNING: Could not extract REDIS_URL. Set it manually:"
+  echo "  flyctl secrets set -a umbra-ai-director REDIS_URL=redis://..."
+  echo "  flyctl secrets set -a umbra-game-logic REDIS_URL=redis://..."
+fi
+
+# 4. Set secrets for AI Director
+echo ""
+echo "--- Setting AI Director secrets ---"
+flyctl secrets set -a umbra-ai-director \
+  LOG_LEVEL=info \
+  ${REDIS_URL:+REDIS_URL=$REDIS_URL}
+
+# 5. Set secrets for Game Logic
+echo ""
+echo "--- Setting Game Logic secrets ---"
+flyctl secrets set -a umbra-game-logic \
+  LOG_LEVEL=info \
+  ${REDIS_URL:+REDIS_URL=$REDIS_URL}
+
+# 6. Set secrets for Payment (DATABASE_URL auto-set by postgres attach)
+echo ""
+echo "--- Setting Payment secrets ---"
+flyctl secrets set -a umbra-payment \
+  STRIPE_SECRET_KEY=sk_test_placeholder \
+  STRIPE_WEBHOOK_SECRET=whsec_placeholder \
+  LOG_LEVEL=info
+
+echo ""
+echo "=== Setup complete ==="
+echo "Next steps:"
+echo "  1. Replace placeholder Stripe keys with real test keys"
+echo "  2. If REDIS_URL wasn't auto-detected, set it manually for ai-director and game-logic"
+echo "  3. Deploy services: ./scripts/fly-deploy.sh"


### PR DESCRIPTION
## Summary
- New `scripts/fly-setup.sh`: provisions managed Postgres + Upstash Redis on Fly.io, configures secrets for all apps
- New `scripts/fly-deploy.sh`: ordered deployment (stateless first, then migrations), with health checks and rollback guidance
- Updated `.env.example` with Nakama HTTP URL, client VITE_API_URL, Fly.io production notes

## Test plan
- [ ] `bash -n scripts/fly-setup.sh` — no syntax errors
- [ ] `bash -n scripts/fly-deploy.sh` — no syntax errors
- [ ] Review .env.example covers all required variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)