### PR TITLE
feat: procedural dungeon generation with rune card system

### DIFF
--- a/client/src/game/config.ts
+++ b/client/src/game/config.ts
@@ -1,6 +1,7 @@
 import { Types } from 'phaser'
 import { MainScene } from './scenes/MainScene'
 import { CombatScene } from './scenes/CombatScene'
+import { DungeonScene } from './scenes/DungeonScene'
 
 export const gameConfig: Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -14,7 +15,7 @@ export const gameConfig: Types.Core.GameConfig = {
       debug: false
     }
   },
-  scene: [MainScene, CombatScene],
+  scene: [MainScene, CombatScene, DungeonScene],
   scale: {
     mode: Phaser.Scale.FIT,
     autoCenter: Phaser.Scale.CENTER_BOTH

--- a/client/src/game/dungeon/DungeonGenerator.ts
+++ b/client/src/game/dungeon/DungeonGenerator.ts
@@ -1,13 +1,254 @@
-import { RoomTemplate, roomTemplates } from './RoomTemplates';
+import { RoomTemplate, roomTemplates } from './RoomTemplates'
+
+// ---------------------------------------------------------------------------
+// Seeded PRNG — mulberry32
+// ---------------------------------------------------------------------------
+
+function hashSeed(str: string): number {
+    let h = 0
+    for (let i = 0; i < str.length; i++) {
+        h = (Math.imul(31, h) + str.charCodeAt(i)) | 0
+    }
+    return h >>> 0
+}
+
+function mulberry32(seed: number): () => number {
+    let s = seed | 0
+    return () => {
+        s = (s + 0x6d2b79f5) | 0
+        let t = Math.imul(s ^ (s >>> 15), 1 | s)
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dungeon graph types
+// ---------------------------------------------------------------------------
+
+export type RoomType = 'start' | 'combat' | 'elite' | 'treasure' | 'event' | 'rest' | 'boss'
+
+export interface DungeonNode {
+    id: number
+    type: RoomType
+    template: RoomTemplate
+    connections: number[]
+    visited: boolean
+    cleared: boolean
+    corruption: number
+    depth: number
+    x: number
+    y: number
+}
+
+export interface DungeonGraph {
+    nodes: DungeonNode[]
+    seed: string
+    floor: number
+    totalCorruption: number
+}
+
+// ---------------------------------------------------------------------------
+// Room pool weights by depth
+// ---------------------------------------------------------------------------
+
+interface WeightedType {
+    type: RoomType
+    weight: number
+}
+
+const DEPTH_WEIGHTS: Record<string, WeightedType[]> = {
+    early: [
+        { type: 'combat', weight: 50 },
+        { type: 'treasure', weight: 20 },
+        { type: 'event', weight: 20 },
+        { type: 'rest', weight: 10 },
+    ],
+    mid: [
+        { type: 'combat', weight: 40 },
+        { type: 'elite', weight: 20 },
+        { type: 'treasure', weight: 15 },
+        { type: 'event', weight: 15 },
+        { type: 'rest', weight: 10 },
+    ],
+    late: [
+        { type: 'combat', weight: 30 },
+        { type: 'elite', weight: 30 },
+        { type: 'treasure', weight: 10 },
+        { type: 'event', weight: 10 },
+        { type: 'rest', weight: 20 },
+    ],
+}
+
+// ---------------------------------------------------------------------------
+// DungeonGenerator
+// ---------------------------------------------------------------------------
 
 export class DungeonGenerator {
-    generateDungeon(_seed: string): RoomTemplate[] {
-        // For now, a simple static dungeon
-        return [
-            roomTemplates.find(t => t.id === 'start_room')!,
-            roomTemplates.find(t => t.id === 'combat_room_1')!,
-            roomTemplates.find(t => t.id === 'treasure_room')!,
-            roomTemplates.find(t => t.id === 'boss_room')!,
-        ];
+    private rng!: () => number
+    private floor: number = 1
+
+    /**
+     * Generate a full dungeon graph for a given seed and floor level.
+     * The dungeon is a directed acyclic graph with branching paths.
+     */
+    generateDungeon(seed: string, floor: number = 1): DungeonGraph {
+        this.rng = mulberry32(hashSeed(seed + floor))
+        this.floor = floor
+
+        const totalRooms = this.getRoomCount()
+        const maxDepth = totalRooms - 1
+        const nodes: DungeonNode[] = []
+
+        // Layer 0: Start room
+        nodes.push(this.createNode(0, 'start', 0, 0.5, 0))
+
+        // Layers 1..maxDepth-1: procedural rooms
+        let nodeId = 1
+        const layers: number[][] = [[0]]
+
+        for (let depth = 1; depth < maxDepth; depth++) {
+            const branchCount = depth === 1 ? 2 : this.rng() < 0.35 ? 3 : 2
+            const layer: number[] = []
+
+            for (let b = 0; b < branchCount; b++) {
+                const type = this.pickRoomType(depth, maxDepth)
+                const xPos = (b + 0.5) / branchCount
+                const node = this.createNode(nodeId++, type, depth, xPos, depth)
+                nodes.push(node)
+                layer.push(node.id)
+            }
+
+            // Connect previous layer to this layer
+            const prevLayer = layers[layers.length - 1]
+            this.connectLayers(prevLayer, layer, nodes)
+
+            layers.push(layer)
+        }
+
+        // Final layer: Boss room
+        const bossNode = this.createNode(nodeId, 'boss', maxDepth, 0.5, maxDepth)
+        nodes.push(bossNode)
+
+        // Connect last combat layer to boss
+        const lastLayer = layers[layers.length - 1]
+        for (const prevId of lastLayer) {
+            nodes[prevId].connections.push(bossNode.id)
+        }
+
+        const baseCorruption = Math.min(100, floor * 8 + this.rng() * 15)
+
+        return {
+            nodes,
+            seed,
+            floor,
+            totalCorruption: Math.round(baseCorruption),
+        }
+    }
+
+    /**
+     * Legacy compatibility — returns flat room list.
+     */
+    generateLinear(seed: string): RoomTemplate[] {
+        const graph = this.generateDungeon(seed)
+        return graph.nodes.map(n => n.template)
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    private getRoomCount(): number {
+        const base = 6
+        const floorBonus = Math.min(4, Math.floor(this.floor / 3))
+        return base + floorBonus + (this.rng() < 0.3 ? 1 : 0)
+    }
+
+    private pickRoomType(depth: number, maxDepth: number): RoomType {
+        const ratio = depth / maxDepth
+        let pool: WeightedType[]
+        if (ratio < 0.33) pool = DEPTH_WEIGHTS.early
+        else if (ratio < 0.66) pool = DEPTH_WEIGHTS.mid
+        else pool = DEPTH_WEIGHTS.late
+
+        const total = pool.reduce((s, w) => s + w.weight, 0)
+        let roll = this.rng() * total
+
+        for (const entry of pool) {
+            roll -= entry.weight
+            if (roll <= 0) return entry.type
+        }
+        return 'combat'
+    }
+
+    private createNode(
+        id: number,
+        type: RoomType,
+        depth: number,
+        xRatio: number,
+        _layer: number,
+    ): DungeonNode {
+        const template = this.getTemplate(type)
+        const corruption = type === 'boss'
+            ? Math.round(20 + this.floor * 5)
+            : Math.round(this.rng() * 10 * (1 + depth * 0.3))
+
+        return {
+            id,
+            type,
+            template,
+            connections: [],
+            visited: type === 'start',
+            cleared: false,
+            corruption,
+            depth,
+            x: xRatio,
+            y: depth,
+        }
+    }
+
+    private getTemplate(type: RoomType): RoomTemplate {
+        const matchType = type === 'elite' ? 'combat' :
+            type === 'event' ? 'treasure' :
+            type === 'rest' ? 'start' :
+            type
+
+        const candidates = roomTemplates.filter(t => t.type === matchType)
+        if (candidates.length === 0) return roomTemplates[0]
+
+        const idx = Math.floor(this.rng() * candidates.length)
+        return candidates[idx]
+    }
+
+    private connectLayers(
+        prevLayer: number[],
+        currentLayer: number[],
+        nodes: DungeonNode[],
+    ): void {
+        // Ensure every node in current layer has at least one parent
+        for (const curId of currentLayer) {
+            const parentIdx = Math.floor(this.rng() * prevLayer.length)
+            const parentId = prevLayer[parentIdx]
+            if (!nodes[parentId].connections.includes(curId)) {
+                nodes[parentId].connections.push(curId)
+            }
+        }
+
+        // Ensure every node in previous layer has at least one child
+        for (const prevId of prevLayer) {
+            if (nodes[prevId].connections.length === 0) {
+                const childIdx = Math.floor(this.rng() * currentLayer.length)
+                nodes[prevId].connections.push(currentLayer[childIdx])
+            }
+        }
+
+        // Random cross-connections for variety
+        if (this.rng() < 0.3 && prevLayer.length > 1 && currentLayer.length > 1) {
+            const extraParent = prevLayer[Math.floor(this.rng() * prevLayer.length)]
+            const extraChild = currentLayer[Math.floor(this.rng() * currentLayer.length)]
+            if (!nodes[extraParent].connections.includes(extraChild)) {
+                nodes[extraParent].connections.push(extraChild)
+            }
+        }
     }
 }

--- a/client/src/game/dungeon/RoomTemplates.ts
+++ b/client/src/game/dungeon/RoomTemplates.ts
@@ -53,4 +53,43 @@ export const roomTemplates: RoomTemplate[] = [
         doors: { south: { x: 800, y: 1200 } },
         obstacles: [],
     },
+    {
+        id: 'combat_room_2',
+        type: 'combat',
+        width: 1000,
+        height: 800,
+        enemySlots: [
+            { x: 300, y: 400, enemyType: 'fire_imp', count: 3 },
+            { x: 700, y: 400, enemyType: 'blood_wraith', count: 2 },
+        ],
+        doors: { south: { x: 500, y: 800 }, north: { x: 500, y: 0 }, east: { x: 1000, y: 400 } },
+        obstacles: [
+            { type: 'pillar', x: 500, y: 200 },
+            { type: 'pillar', x: 500, y: 600 },
+        ],
+    },
+    {
+        id: 'combat_room_3',
+        type: 'combat',
+        width: 1400,
+        height: 900,
+        enemySlots: [
+            { x: 400, y: 300, enemyType: 'void_sentinel', count: 2 },
+            { x: 1000, y: 600, enemyType: 'shadow_wraith', count: 3 },
+        ],
+        doors: { south: { x: 700, y: 900 }, west: { x: 0, y: 450 } },
+        obstacles: [
+            { type: 'wall', x: 700, y: 300 },
+            { type: 'wall', x: 700, y: 600 },
+        ],
+    },
+    {
+        id: 'treasure_room_2',
+        type: 'treasure',
+        width: 500,
+        height: 500,
+        enemySlots: [],
+        doors: { south: { x: 250, y: 500 }, north: { x: 250, y: 0 } },
+        obstacles: [],
+    },
 ];

--- a/client/src/game/dungeon/RuneCardSystem.ts
+++ b/client/src/game/dungeon/RuneCardSystem.ts
@@ -1,0 +1,236 @@
+// ---------------------------------------------------------------------------
+// Rune Card System — modifier cards offered between rooms
+// ---------------------------------------------------------------------------
+
+export type RuneRarity = 'common' | 'rare' | 'legendary'
+export type RuneCategory = 'offense' | 'defense' | 'utility' | 'corruption'
+
+export interface RuneCard {
+    id: string
+    name: string
+    description: string
+    rarity: RuneRarity
+    category: RuneCategory
+    effect: RuneEffect
+    corruptionCost: number
+}
+
+export interface RuneEffect {
+    stat: string
+    value: number
+    type: 'flat' | 'percent'
+    duration?: 'permanent' | 'floor'
+}
+
+// ---------------------------------------------------------------------------
+// Card pool
+// ---------------------------------------------------------------------------
+
+const RUNE_POOL: RuneCard[] = [
+    // Offense — Common
+    {
+        id: 'sharpened_edge',
+        name: 'Sharpened Edge',
+        description: '+10% Attack Damage',
+        rarity: 'common',
+        category: 'offense',
+        effect: { stat: 'atk', value: 10, type: 'percent' },
+        corruptionCost: 0,
+    },
+    {
+        id: 'swift_strikes',
+        name: 'Swift Strikes',
+        description: '+15% Attack Speed',
+        rarity: 'common',
+        category: 'offense',
+        effect: { stat: 'atk_speed', value: 15, type: 'percent' },
+        corruptionCost: 0,
+    },
+    {
+        id: 'keen_eye',
+        name: 'Keen Eye',
+        description: '+5% Critical Chance',
+        rarity: 'common',
+        category: 'offense',
+        effect: { stat: 'crit_chance', value: 5, type: 'flat' },
+        corruptionCost: 0,
+    },
+
+    // Offense — Rare
+    {
+        id: 'blood_frenzy',
+        name: 'Blood Frenzy',
+        description: '+25% Damage, take 10% more damage',
+        rarity: 'rare',
+        category: 'offense',
+        effect: { stat: 'atk', value: 25, type: 'percent' },
+        corruptionCost: 5,
+    },
+    {
+        id: 'void_infusion',
+        name: 'Void Infusion',
+        description: '+20% Skill Damage',
+        rarity: 'rare',
+        category: 'offense',
+        effect: { stat: 'skill_damage', value: 20, type: 'percent' },
+        corruptionCost: 3,
+    },
+
+    // Defense — Common
+    {
+        id: 'iron_skin',
+        name: 'Iron Skin',
+        description: '+15 Defense',
+        rarity: 'common',
+        category: 'defense',
+        effect: { stat: 'def', value: 15, type: 'flat' },
+        corruptionCost: 0,
+    },
+    {
+        id: 'vitality',
+        name: 'Vitality',
+        description: '+50 Max HP',
+        rarity: 'common',
+        category: 'defense',
+        effect: { stat: 'max_hp', value: 50, type: 'flat' },
+        corruptionCost: 0,
+    },
+
+    // Defense — Rare
+    {
+        id: 'vampiric_touch',
+        name: 'Vampiric Touch',
+        description: 'Heal 3% of damage dealt',
+        rarity: 'rare',
+        category: 'defense',
+        effect: { stat: 'lifesteal', value: 3, type: 'percent' },
+        corruptionCost: 4,
+    },
+
+    // Utility
+    {
+        id: 'treasure_hunter',
+        name: 'Treasure Hunter',
+        description: '+30% Cendres from enemies',
+        rarity: 'common',
+        category: 'utility',
+        effect: { stat: 'cendres_bonus', value: 30, type: 'percent' },
+        corruptionCost: 0,
+    },
+    {
+        id: 'experience_boost',
+        name: 'Experience Boost',
+        description: '+20% XP gain',
+        rarity: 'common',
+        category: 'utility',
+        effect: { stat: 'xp_bonus', value: 20, type: 'percent' },
+        corruptionCost: 0,
+    },
+
+    // Corruption — Legendary (high risk, high reward)
+    {
+        id: 'dark_pact',
+        name: 'Dark Pact',
+        description: '+50% All Damage, +20 Corruption',
+        rarity: 'legendary',
+        category: 'corruption',
+        effect: { stat: 'all_damage', value: 50, type: 'percent' },
+        corruptionCost: 20,
+    },
+    {
+        id: 'shadow_form',
+        name: 'Shadow Form',
+        description: '+2 Dodge Charges, +15 Corruption',
+        rarity: 'legendary',
+        category: 'corruption',
+        effect: { stat: 'dodge_charges', value: 2, type: 'flat' },
+        corruptionCost: 15,
+    },
+]
+
+// ---------------------------------------------------------------------------
+// Rarity weights by corruption level
+// ---------------------------------------------------------------------------
+
+function getRarityWeights(corruption: number): Record<RuneRarity, number> {
+    if (corruption >= 60) return { common: 30, rare: 40, legendary: 30 }
+    if (corruption >= 30) return { common: 45, rare: 40, legendary: 15 }
+    return { common: 60, rare: 35, legendary: 5 }
+}
+
+// ---------------------------------------------------------------------------
+// Card selection (seeded random via passed rng)
+// ---------------------------------------------------------------------------
+
+export function selectRuneCards(
+    rng: () => number,
+    corruption: number,
+    count: number = 3,
+    excludeIds: string[] = [],
+): RuneCard[] {
+    const weights = getRarityWeights(corruption)
+    const available = RUNE_POOL.filter(c => !excludeIds.includes(c.id))
+    const selected: RuneCard[] = []
+
+    for (let i = 0; i < count && available.length > 0; i++) {
+        // Pick rarity
+        const totalWeight = weights.common + weights.rare + weights.legendary
+        let roll = rng() * totalWeight
+        let targetRarity: RuneRarity = 'common'
+
+        if (roll < weights.legendary) {
+            targetRarity = 'legendary'
+        } else if (roll < weights.legendary + weights.rare) {
+            targetRarity = 'rare'
+        }
+
+        // Find candidates of that rarity
+        let candidates = available.filter(c => c.rarity === targetRarity)
+        if (candidates.length === 0) {
+            candidates = available
+        }
+
+        const idx = Math.floor(rng() * candidates.length)
+        const card = candidates[idx]
+        selected.push(card)
+
+        // Remove from available to avoid duplicates
+        const removeIdx = available.indexOf(card)
+        if (removeIdx >= 0) available.splice(removeIdx, 1)
+    }
+
+    return selected
+}
+
+// ---------------------------------------------------------------------------
+// Active runes tracker
+// ---------------------------------------------------------------------------
+
+export class RuneInventory {
+    private activeRunes: RuneCard[] = []
+    private totalCorruption: number = 0
+
+    addRune(card: RuneCard): void {
+        this.activeRunes.push(card)
+        this.totalCorruption += card.corruptionCost
+    }
+
+    getActiveRunes(): readonly RuneCard[] {
+        return this.activeRunes
+    }
+
+    getCorruption(): number {
+        return this.totalCorruption
+    }
+
+    getStatBonus(stat: string): number {
+        return this.activeRunes
+            .filter(r => r.effect.stat === stat)
+            .reduce((sum, r) => sum + r.effect.value, 0)
+    }
+
+    reset(): void {
+        this.activeRunes = []
+        this.totalCorruption = 0
+    }
+}

--- a/client/src/game/scenes/DungeonScene.ts
+++ b/client/src/game/scenes/DungeonScene.ts
@@ -1,0 +1,585 @@
+import Phaser from 'phaser'
+import { DungeonGenerator, DungeonGraph, DungeonNode } from '../dungeon/DungeonGenerator'
+import { RuneInventory, selectRuneCards, RuneCard } from '../dungeon/RuneCardSystem'
+import { generateDungeon as fetchAIDungeon } from '../../services/ai-director'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DungeonSceneData {
+    playerLevel: number
+    talents: number[]
+    inventory: string[]
+    floor?: number
+    seed?: string
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAP_MARGIN = 40
+const MAP_WIDTH = 240
+const MAP_HEIGHT = 400
+const NODE_RADIUS = 12
+const ROOM_TRANSITION_MS = 600
+
+// Color palette
+const COLORS = {
+    bg: 0x0f0f1a,
+    mapBg: 0x1a1a2e,
+    start: 0x4488ff,
+    combat: 0xcc4444,
+    elite: 0xff8800,
+    treasure: 0xffd700,
+    event: 0x9370db,
+    rest: 0x44cc88,
+    boss: 0xff2222,
+    visited: 0x666666,
+    current: 0x00ffaa,
+    connection: 0x333355,
+    connectionActive: 0x6644cc,
+}
+
+// ---------------------------------------------------------------------------
+// DungeonScene
+// ---------------------------------------------------------------------------
+
+export class DungeonScene extends Phaser.Scene {
+    private dungeon!: DungeonGraph
+    private currentNodeId: number = 0
+    private runeInventory: RuneInventory = new RuneInventory()
+    private playerData!: DungeonSceneData
+    private floor: number = 1
+    private roomsCleared: number = 0
+
+    // Graphics
+    private mapGraphics!: Phaser.GameObjects.Graphics
+    private roomInfoGroup!: Phaser.GameObjects.Group
+    private runeOverlayGroup!: Phaser.GameObjects.Group
+    private hudGroup!: Phaser.GameObjects.Group
+    private showingRuneCards: boolean = false
+
+    // RNG for rune cards (shared seed)
+    private rng!: () => number
+
+    constructor() {
+        super({ key: 'DungeonScene' })
+    }
+
+    // -----------------------------------------------------------------------
+    // Lifecycle
+    // -----------------------------------------------------------------------
+
+    init(data: DungeonSceneData): void {
+        this.playerData = {
+            playerLevel: data.playerLevel ?? 1,
+            talents: data.talents ?? [],
+            inventory: data.inventory ?? [],
+            floor: data.floor ?? 1,
+            seed: data.seed ?? `run_${Date.now()}`,
+        }
+        this.floor = this.playerData.floor!
+        this.roomsCleared = 0
+        this.runeInventory.reset()
+    }
+
+    create(): void {
+        this.cameras.main.setBackgroundColor(COLORS.bg)
+        this.mapGraphics = this.add.graphics()
+        this.roomInfoGroup = this.add.group()
+        this.runeOverlayGroup = this.add.group()
+        this.hudGroup = this.add.group()
+
+        // Generate dungeon
+        const generator = new DungeonGenerator()
+        this.dungeon = generator.generateDungeon(this.playerData.seed!, this.floor)
+        this.currentNodeId = 0
+
+        // Create seeded RNG for rune card draws
+        this.rng = this.createRng(this.playerData.seed! + '_runes')
+
+        // Try fetching AI-enhanced layout (non-blocking)
+        this.fetchAILayout()
+
+        // Draw initial state
+        this.drawMap()
+        this.drawHUD()
+        this.drawRoomInfo(this.dungeon.nodes[0])
+    }
+
+    // -----------------------------------------------------------------------
+    // AI Director integration
+    // -----------------------------------------------------------------------
+
+    private async fetchAILayout(): Promise<void> {
+        try {
+            const aiLayout = await fetchAIDungeon(
+                this.floor,
+                this.dungeon.totalCorruption,
+                this.playerData.playerLevel,
+            )
+            // AI can enhance corruption effects and narrative
+            if (aiLayout.corruptionEffects?.length > 0) {
+                this.applyCorruptionEffects(aiLayout.corruptionEffects)
+            }
+        } catch {
+            // AI director unavailable — proceed with local generation
+        }
+    }
+
+    private applyCorruptionEffects(effects: string[]): void {
+        // Apply the first effect as a visual cue
+        if (effects.length > 0) {
+            const effectText = this.add.text(
+                this.scale.width / 2, 50,
+                effects[0],
+                { fontSize: '12px', color: '#9370db', fontStyle: 'italic' },
+            ).setOrigin(0.5).setAlpha(0.8)
+            this.hudGroup.add(effectText)
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Minimap rendering
+    // -----------------------------------------------------------------------
+
+    private drawMap(): void {
+        this.mapGraphics.clear()
+
+        const mapX = this.scale.width - MAP_WIDTH - MAP_MARGIN
+        const mapY = MAP_MARGIN
+
+        // Map background
+        this.mapGraphics.fillStyle(COLORS.mapBg, 0.85)
+        this.mapGraphics.fillRoundedRect(mapX, mapY, MAP_WIDTH, MAP_HEIGHT, 8)
+        this.mapGraphics.lineStyle(1, 0x444466, 0.6)
+        this.mapGraphics.strokeRoundedRect(mapX, mapY, MAP_WIDTH, MAP_HEIGHT, 8)
+
+        // Title
+        this.add.text(mapX + MAP_WIDTH / 2, mapY + 12, `Floor ${this.floor}`, {
+            fontSize: '13px', color: '#aaa', fontStyle: 'bold',
+        }).setOrigin(0.5).setDepth(10)
+
+        const maxDepth = Math.max(...this.dungeon.nodes.map(n => n.depth))
+        const innerPadding = 20
+
+        // Draw connections
+        this.mapGraphics.lineStyle(2, COLORS.connection, 0.5)
+        for (const node of this.dungeon.nodes) {
+            const fromPos = this.getMapNodePos(node, mapX, mapY, innerPadding, maxDepth)
+            for (const connId of node.connections) {
+                const targetNode = this.dungeon.nodes.find(n => n.id === connId)
+                if (!targetNode) continue
+                const toPos = this.getMapNodePos(targetNode, mapX, mapY, innerPadding, maxDepth)
+
+                const isActive = node.visited && this.isReachable(connId)
+                this.mapGraphics.lineStyle(2, isActive ? COLORS.connectionActive : COLORS.connection, isActive ? 0.8 : 0.4)
+                this.mapGraphics.lineBetween(fromPos.x, fromPos.y, toPos.x, toPos.y)
+            }
+        }
+
+        // Draw nodes
+        for (const node of this.dungeon.nodes) {
+            const pos = this.getMapNodePos(node, mapX, mapY, innerPadding, maxDepth)
+            const isCurrent = node.id === this.currentNodeId
+            const isReachable = this.isReachable(node.id)
+
+            let color = this.getNodeColor(node.type)
+            let alpha = 0.4
+
+            if (isCurrent) {
+                color = COLORS.current
+                alpha = 1
+            } else if (node.visited) {
+                color = COLORS.visited
+                alpha = 0.6
+            } else if (isReachable) {
+                alpha = 0.9
+            }
+
+            this.mapGraphics.fillStyle(color, alpha)
+            this.mapGraphics.fillCircle(pos.x, pos.y, isCurrent ? NODE_RADIUS + 2 : NODE_RADIUS)
+
+            if (isCurrent) {
+                this.mapGraphics.lineStyle(2, 0xffffff, 0.8)
+                this.mapGraphics.strokeCircle(pos.x, pos.y, NODE_RADIUS + 4)
+            }
+
+            // Make reachable nodes clickable
+            if (isReachable && !isCurrent) {
+                const hitArea = this.add.circle(pos.x, pos.y, NODE_RADIUS + 4)
+                    .setInteractive({ useHandCursor: true })
+                    .setAlpha(0.01)
+                    .on('pointerdown', () => this.moveToNode(node))
+                this.roomInfoGroup.add(hitArea)
+            }
+        }
+    }
+
+    private getMapNodePos(
+        node: DungeonNode,
+        mapX: number,
+        mapY: number,
+        padding: number,
+        maxDepth: number,
+    ): { x: number; y: number } {
+        const headerOffset = 28
+        const usableHeight = MAP_HEIGHT - headerOffset - padding * 2
+        const usableWidth = MAP_WIDTH - padding * 2
+
+        return {
+            x: mapX + padding + node.x * usableWidth,
+            y: mapY + headerOffset + padding + (node.depth / Math.max(1, maxDepth)) * usableHeight,
+        }
+    }
+
+    private getNodeColor(type: string): number {
+        return (COLORS as Record<string, number>)[type] ?? COLORS.combat
+    }
+
+    // -----------------------------------------------------------------------
+    // Room info panel
+    // -----------------------------------------------------------------------
+
+    private drawRoomInfo(node: DungeonNode): void {
+        // Clear previous
+        this.roomInfoGroup.clear(true, true)
+
+        const panelX = MAP_MARGIN
+        const panelY = MAP_MARGIN
+        const panelW = 350
+        const panelH = 180
+
+        // Panel background
+        const bg = this.add.graphics()
+        bg.fillStyle(0x1a1a2e, 0.9)
+        bg.fillRoundedRect(panelX, panelY, panelW, panelH, 8)
+        bg.lineStyle(1, 0x444466, 0.5)
+        bg.strokeRoundedRect(panelX, panelY, panelW, panelH, 8)
+        this.roomInfoGroup.add(bg)
+
+        const typeLabel = node.type.toUpperCase()
+        const typeColor = `#${this.getNodeColor(node.type).toString(16).padStart(6, '0')}`
+
+        this.roomInfoGroup.add(this.add.text(panelX + 16, panelY + 12, typeLabel, {
+            fontSize: '18px', color: typeColor, fontStyle: 'bold',
+        }))
+
+        this.roomInfoGroup.add(this.add.text(panelX + 16, panelY + 40, node.template.id.replace(/_/g, ' '), {
+            fontSize: '14px', color: '#ccc',
+        }))
+
+        const corruptionColor = node.corruption > 15 ? '#ff4444' : node.corruption > 5 ? '#ffaa44' : '#888'
+        this.roomInfoGroup.add(this.add.text(panelX + 16, panelY + 65, `Corruption: ${node.corruption}`, {
+            fontSize: '13px', color: corruptionColor,
+        }))
+
+        // Enemy info for combat/elite rooms
+        if ((node.type === 'combat' || node.type === 'elite') && node.template.enemySlots.length > 0) {
+            const enemies = node.template.enemySlots.map(s => `${s.count}x ${s.enemyType.replace(/_/g, ' ')}`).join(', ')
+            this.roomInfoGroup.add(this.add.text(panelX + 16, panelY + 88, `Enemies: ${enemies}`, {
+                fontSize: '12px', color: '#cc8888',
+            }))
+        }
+
+        // Show connections
+        const nextRooms = node.connections.map(id => {
+            const n = this.dungeon.nodes.find(nd => nd.id === id)
+            return n ? n.type : '?'
+        }).join(', ')
+        if (nextRooms) {
+            this.roomInfoGroup.add(this.add.text(panelX + 16, panelY + 115, `Paths: ${nextRooms}`, {
+                fontSize: '12px', color: '#888',
+            }))
+        }
+
+        // Action button
+        if (node.id === this.currentNodeId && !node.cleared && node.type !== 'start') {
+            const btn = this.add.text(panelX + 16, panelY + 142, '[ ENTER ROOM ]', {
+                fontSize: '15px', color: '#00ffaa', fontStyle: 'bold',
+            }).setInteractive({ useHandCursor: true })
+                .on('pointerdown', () => this.enterRoom(node))
+            this.roomInfoGroup.add(btn)
+        } else if (node.cleared) {
+            this.roomInfoGroup.add(this.add.text(panelX + 16, panelY + 142, 'CLEARED', {
+                fontSize: '15px', color: '#666',
+            }))
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // HUD
+    // -----------------------------------------------------------------------
+
+    private drawHUD(): void {
+        this.hudGroup.clear(true, true)
+
+        const y = this.scale.height - 50
+
+        // Active runes display
+        const runes = this.runeInventory.getActiveRunes()
+        if (runes.length > 0) {
+            const runeLabel = `Runes: ${runes.map(r => r.name).join(' | ')}`
+            this.hudGroup.add(this.add.text(MAP_MARGIN, y, runeLabel, {
+                fontSize: '12px', color: '#9370db',
+            }))
+        }
+
+        // Corruption meter
+        const corruption = this.runeInventory.getCorruption() + this.dungeon.totalCorruption
+        const corruptionColor = corruption > 50 ? '#ff4444' : corruption > 25 ? '#ffaa44' : '#888'
+        this.hudGroup.add(this.add.text(MAP_MARGIN, y + 18, `Total Corruption: ${corruption}%`, {
+            fontSize: '12px', color: corruptionColor,
+        }))
+
+        // Rooms cleared
+        this.hudGroup.add(this.add.text(this.scale.width / 2, y + 8, `Rooms: ${this.roomsCleared} | Floor: ${this.floor}`, {
+            fontSize: '14px', color: '#aaa',
+        }).setOrigin(0.5))
+
+        // Back to hub button
+        const backBtn = this.add.text(this.scale.width - MAP_MARGIN, y + 8, '[ ABANDON RUN ]', {
+            fontSize: '13px', color: '#ff4444',
+        }).setOrigin(1, 0.5).setInteractive({ useHandCursor: true })
+            .on('pointerdown', () => this.abandonRun())
+        this.hudGroup.add(backBtn)
+    }
+
+    // -----------------------------------------------------------------------
+    // Navigation
+    // -----------------------------------------------------------------------
+
+    private isReachable(nodeId: number): boolean {
+        const currentNode = this.dungeon.nodes[this.currentNodeId]
+        return currentNode.connections.includes(nodeId)
+    }
+
+    private moveToNode(node: DungeonNode): void {
+        if (this.showingRuneCards) return
+        if (!this.isReachable(node.id)) return
+
+        // Transition effect
+        this.cameras.main.fadeOut(ROOM_TRANSITION_MS / 2, 0, 0, 0)
+        this.time.delayedCall(ROOM_TRANSITION_MS / 2, () => {
+            this.currentNodeId = node.id
+            node.visited = true
+            this.drawMap()
+            this.drawRoomInfo(node)
+            this.drawHUD()
+            this.cameras.main.fadeIn(ROOM_TRANSITION_MS / 2, 0, 0, 0)
+        })
+    }
+
+    private enterRoom(node: DungeonNode): void {
+        if (node.type === 'combat' || node.type === 'elite' || node.type === 'boss') {
+            // Transition to CombatScene with room context
+            this.scene.start('CombatScene', {
+                playerLevel: this.playerData.playerLevel,
+                talents: this.playerData.talents,
+                inventory: this.playerData.inventory,
+                dungeonContext: {
+                    floor: this.floor,
+                    roomType: node.type,
+                    corruption: node.corruption,
+                    runeBuffs: this.runeInventory.getActiveRunes().map(r => ({
+                        stat: r.effect.stat,
+                        value: r.effect.value,
+                        type: r.effect.type,
+                    })),
+                },
+            })
+        } else if (node.type === 'treasure') {
+            // Mark cleared and offer rune cards
+            node.cleared = true
+            this.roomsCleared++
+            this.showRuneCardSelection()
+        } else if (node.type === 'rest') {
+            // Heal & mark cleared
+            node.cleared = true
+            this.roomsCleared++
+            this.drawRoomInfo(node)
+            this.drawHUD()
+        } else if (node.type === 'event') {
+            // Random event — simplified to rune card offer
+            node.cleared = true
+            this.roomsCleared++
+            this.showRuneCardSelection()
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Rune card selection overlay
+    // -----------------------------------------------------------------------
+
+    private showRuneCardSelection(): void {
+        this.showingRuneCards = true
+        this.runeOverlayGroup.clear(true, true)
+
+        const { width, height } = this.scale
+
+        // Backdrop
+        const bg = this.add.rectangle(width / 2, height / 2, width, height, 0x000000, 0.8)
+            .setInteractive()
+        this.runeOverlayGroup.add(bg)
+
+        this.runeOverlayGroup.add(
+            this.add.text(width / 2, 60, 'CHOOSE A RUNE', {
+                fontSize: '24px', color: '#ffd700', fontStyle: 'bold',
+            }).setOrigin(0.5)
+        )
+
+        // Get 3 cards
+        const existingIds = this.runeInventory.getActiveRunes().map(r => r.id)
+        const cards = selectRuneCards(this.rng, this.dungeon.totalCorruption, 3, existingIds)
+
+        const cardWidth = 200
+        const cardHeight = 260
+        const spacing = 30
+        const totalWidth = cards.length * cardWidth + (cards.length - 1) * spacing
+        const startX = (width - totalWidth) / 2
+
+        cards.forEach((card, i) => {
+            const cx = startX + i * (cardWidth + spacing) + cardWidth / 2
+            const cy = height / 2
+
+            this.drawRuneCard(cx, cy, cardWidth, cardHeight, card)
+        })
+
+        // Skip button
+        const skipBtn = this.add.text(width / 2, height - 60, '[ SKIP ]', {
+            fontSize: '16px', color: '#888',
+        }).setOrigin(0.5).setInteractive({ useHandCursor: true })
+            .on('pointerdown', () => this.closeRuneSelection())
+        this.runeOverlayGroup.add(skipBtn)
+    }
+
+    private drawRuneCard(
+        cx: number,
+        cy: number,
+        w: number,
+        h: number,
+        card: RuneCard,
+    ): void {
+        const rarityColors: Record<string, number> = {
+            common: 0x888888,
+            rare: 0x4488ff,
+            legendary: 0xffd700,
+        }
+
+        const borderColor = rarityColors[card.rarity] ?? 0x888888
+
+        // Card background
+        const cardBg = this.add.graphics()
+        cardBg.fillStyle(0x1a1a2e, 0.95)
+        cardBg.fillRoundedRect(cx - w / 2, cy - h / 2, w, h, 10)
+        cardBg.lineStyle(2, borderColor, 0.9)
+        cardBg.strokeRoundedRect(cx - w / 2, cy - h / 2, w, h, 10)
+        this.runeOverlayGroup.add(cardBg)
+
+        // Rarity tag
+        this.runeOverlayGroup.add(
+            this.add.text(cx, cy - h / 2 + 20, card.rarity.toUpperCase(), {
+                fontSize: '10px', color: `#${borderColor.toString(16).padStart(6, '0')}`,
+            }).setOrigin(0.5)
+        )
+
+        // Category icon
+        const categoryIcons: Record<string, string> = {
+            offense: 'ATK', defense: 'DEF', utility: 'UTL', corruption: 'COR',
+        }
+        this.runeOverlayGroup.add(
+            this.add.text(cx, cy - h / 2 + 45, categoryIcons[card.category] ?? '?', {
+                fontSize: '24px', color: '#fff', fontStyle: 'bold',
+            }).setOrigin(0.5)
+        )
+
+        // Name
+        this.runeOverlayGroup.add(
+            this.add.text(cx, cy + 10, card.name, {
+                fontSize: '14px', color: '#fff', fontStyle: 'bold', align: 'center',
+                wordWrap: { width: w - 20 },
+            }).setOrigin(0.5)
+        )
+
+        // Description
+        this.runeOverlayGroup.add(
+            this.add.text(cx, cy + 40, card.description, {
+                fontSize: '12px', color: '#aaa', align: 'center',
+                wordWrap: { width: w - 20 },
+            }).setOrigin(0.5)
+        )
+
+        // Corruption cost
+        if (card.corruptionCost > 0) {
+            this.runeOverlayGroup.add(
+                this.add.text(cx, cy + h / 2 - 40, `+${card.corruptionCost} Corruption`, {
+                    fontSize: '11px', color: '#ff4444',
+                }).setOrigin(0.5)
+            )
+        }
+
+        // Click to select
+        const hitArea = this.add.rectangle(cx, cy, w, h)
+            .setInteractive({ useHandCursor: true })
+            .setAlpha(0.01)
+            .on('pointerover', () => {
+                cardBg.clear()
+                cardBg.fillStyle(0x2a2a3e, 0.95)
+                cardBg.fillRoundedRect(cx - w / 2, cy - h / 2, w, h, 10)
+                cardBg.lineStyle(3, borderColor, 1)
+                cardBg.strokeRoundedRect(cx - w / 2, cy - h / 2, w, h, 10)
+            })
+            .on('pointerout', () => {
+                cardBg.clear()
+                cardBg.fillStyle(0x1a1a2e, 0.95)
+                cardBg.fillRoundedRect(cx - w / 2, cy - h / 2, w, h, 10)
+                cardBg.lineStyle(2, borderColor, 0.9)
+                cardBg.strokeRoundedRect(cx - w / 2, cy - h / 2, w, h, 10)
+            })
+            .on('pointerdown', () => this.selectRuneCard(card))
+        this.runeOverlayGroup.add(hitArea)
+    }
+
+    private selectRuneCard(card: RuneCard): void {
+        this.runeInventory.addRune(card)
+        this.closeRuneSelection()
+    }
+
+    private closeRuneSelection(): void {
+        this.showingRuneCards = false
+        this.runeOverlayGroup.clear(true, true)
+        this.drawMap()
+        this.drawHUD()
+    }
+
+    // -----------------------------------------------------------------------
+    // Run management
+    // -----------------------------------------------------------------------
+
+    private abandonRun(): void {
+        this.scene.start('HubScene', {
+            xpEarned: this.roomsCleared * 15,
+            cendresEarned: this.roomsCleared * 10,
+        })
+    }
+
+    // -----------------------------------------------------------------------
+    // Seeded RNG helper
+    // -----------------------------------------------------------------------
+
+    private createRng(seed: string): () => number {
+        let h = 0
+        for (let i = 0; i < seed.length; i++) {
+            h = (Math.imul(31, h) + seed.charCodeAt(i)) | 0
+        }
+        let s = h >>> 0
+        return () => {
+            s = (s + 0x6d2b79f5) | 0
+            let t = Math.imul(s ^ (s >>> 15), 1 | s)
+            t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+            return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+        }
+    }
+}

--- a/client/src/game/scenes/index.ts
+++ b/client/src/game/scenes/index.ts
@@ -1,2 +1,3 @@
 export { MainScene } from './MainScene'
 export { CombatScene } from './CombatScene'
+export { DungeonScene } from './DungeonScene'


### PR DESCRIPTION
## Summary
- Enhanced DungeonGenerator with seeded PRNG (mulberry32) and graph-based dungeon layout with branching paths and depth-weighted room types (combat, elite, treasure, event, rest, boss)
- New DungeonScene with interactive minimap, room-by-room navigation, corruption tracking, and async AI Director integration
- New RuneCardSystem with 12 modifier cards across 4 categories (offense/defense/utility/corruption), rarity-weighted selection tied to corruption level
- 3 additional room template variants for combat and treasure rooms

## Test plan
- [ ] Verify DungeonScene loads from HubScene "Enter Dungeon" transition
- [ ] Test minimap renders correctly with node colors and connections
- [ ] Navigate between reachable rooms and verify transition animation
- [ ] Enter combat room and verify CombatScene receives dungeon context
- [ ] Open treasure/event rooms and verify rune card selection overlay
- [ ] Select rune cards and verify they appear in active runes HUD
- [ ] Verify corruption accumulates from rune cards and floor level
- [ ] Abandon run and verify return to HubScene with earned XP/Cendres

🤖 Generated with [Claude Code](https://claude.com/claude-code)