### PR TITLE
feat: wire complete gameplay loop (#67)

### DIFF
--- a/client/src/game/scenes/CombatScene.ts
+++ b/client/src/game/scenes/CombatScene.ts
@@ -176,6 +176,10 @@ const SKILLS: SkillDefinition[] = [
  * (collision, spawning, HUD, wave management) live here.
  */
 export class CombatScene extends Phaser.Scene {
+  // Dungeon context (set when entering from DungeonScene)
+  private fromDungeon = false
+  private dungeonContext: { floor: number; roomType: string; corruption: number; nodeId: number; runeBuffs: { stat: string; value: number; type: string }[] } | null = null
+
   // Entities
   private player!: Player
   private enemies!: Phaser.Physics.Arcade.Group
@@ -223,6 +227,11 @@ export class CombatScene extends Phaser.Scene {
   // ---------------------------------------------------------------------------
   // Lifecycle
   // ---------------------------------------------------------------------------
+
+  init(data: Record<string, unknown>): void {
+    this.fromDungeon = !!data.fromDungeon
+    this.dungeonContext = (data.dungeonContext as typeof this.dungeonContext) ?? null
+  }
 
   create(): void {
     this.resetState()
@@ -1149,7 +1158,7 @@ export class CombatScene extends Phaser.Scene {
     this.restartText = this.add.text(
       width / 2,
       height / 2 + 50,
-      'Press ENTER to restart',
+      this.fromDungeon ? 'Press ENTER to return to hub' : 'Press ENTER to restart',
       {
         fontSize: '18px',
         color: '#aaaaff',
@@ -1193,7 +1202,7 @@ export class CombatScene extends Phaser.Scene {
     this.restartText = this.add.text(
       width / 2,
       height / 2 + 50,
-      'Press ENTER to play again',
+      this.fromDungeon ? 'Press ENTER to continue dungeon' : 'Press ENTER to return to hub',
       {
         fontSize: '18px',
         color: '#aaaaff',
@@ -1209,7 +1218,41 @@ export class CombatScene extends Phaser.Scene {
     if (!keyboard) return
 
     if (Phaser.Input.Keyboard.JustDown(keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER))) {
-      this.scene.restart()
+      const cendresEarned = this.totalKills * 5 + (this.isVictory ? 20 : 0)
+
+      if (this.fromDungeon) {
+        const dungeonState = this.game.registry.get('dungeonState')
+
+        if (this.isVictory && dungeonState) {
+          // Victory: return to dungeon with combat result
+          this.scene.start('DungeonScene', {
+            ...dungeonState.playerData,
+            combatResult: {
+              victory: true,
+              nodeId: dungeonState.currentNodeId,
+              xpEarned: this.totalXp,
+              cendresEarned: cendresEarned,
+            },
+            restoreState: dungeonState,
+          })
+        } else {
+          // Defeat from dungeon: return to hub
+          this.scene.start('HubScene', {
+            xpEarned: this.totalXp,
+            cendresEarned: cendresEarned,
+          })
+        }
+      } else {
+        // Standalone combat
+        if (this.isVictory) {
+          this.scene.start('HubScene', {
+            xpEarned: this.totalXp,
+            cendresEarned: cendresEarned + 30,
+          })
+        } else {
+          this.scene.restart()
+        }
+      }
     }
   }
 }

--- a/client/src/game/scenes/DungeonScene.ts
+++ b/client/src/game/scenes/DungeonScene.ts
@@ -15,6 +15,26 @@ interface DungeonSceneData {
     seed?: string
 }
 
+
+interface CombatResult {
+    victory: boolean
+    nodeId: number
+    xpEarned: number
+    cendresEarned: number
+}
+
+interface DungeonRestoreState {
+    seed: string
+    floor: number
+    currentNodeId: number
+    roomsCleared: number
+    visitedNodes: number[]
+    clearedNodes: number[]
+    activeRunes: RuneCard[]
+    playerData: DungeonSceneData
+    totalXpEarned: number
+    totalCendresEarned: number
+}
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -54,6 +74,14 @@ export class DungeonScene extends Phaser.Scene {
     private floor: number = 1
     private roomsCleared: number = 0
 
+    // Accumulated run rewards
+    private totalXpEarned: number = 0
+    private totalCendresEarned: number = 0
+
+    // Pending combat result
+    private pendingCombatResult?: CombatResult
+    private pendingRestoreState?: DungeonRestoreState
+
     // Graphics
     private mapGraphics!: Phaser.GameObjects.Graphics
     private roomInfoGroup!: Phaser.GameObjects.Group
@@ -72,17 +100,32 @@ export class DungeonScene extends Phaser.Scene {
     // Lifecycle
     // -----------------------------------------------------------------------
 
-    init(data: DungeonSceneData): void {
-        this.playerData = {
-            playerLevel: data.playerLevel ?? 1,
-            talents: data.talents ?? [],
-            inventory: data.inventory ?? [],
-            floor: data.floor ?? 1,
-            seed: data.seed ?? `run_${Date.now()}`,
+    init(data: DungeonSceneData & { combatResult?: CombatResult; restoreState?: DungeonRestoreState }): void {
+        if (data.restoreState && data.combatResult) {
+            const state = data.restoreState
+            this.playerData = state.playerData
+            this.floor = state.floor
+            this.roomsCleared = state.roomsCleared
+            this.totalXpEarned = state.totalXpEarned
+            this.totalCendresEarned = state.totalCendresEarned
+            this.pendingCombatResult = data.combatResult
+            this.pendingRestoreState = state
+        } else {
+            this.playerData = {
+                playerLevel: data.playerLevel ?? 1,
+                talents: data.talents ?? [],
+                inventory: data.inventory ?? [],
+                floor: data.floor ?? 1,
+                seed: data.seed ?? 'run_' + Date.now(),
+            }
+            this.floor = this.playerData.floor!
+            this.roomsCleared = 0
+            this.totalXpEarned = 0
+            this.totalCendresEarned = 0
+            this.runeInventory.reset()
+            this.pendingCombatResult = undefined
+            this.pendingRestoreState = undefined
         }
-        this.floor = this.playerData.floor!
-        this.roomsCleared = 0
-        this.runeInventory.reset()
     }
 
     create(): void {
@@ -100,13 +143,95 @@ export class DungeonScene extends Phaser.Scene {
         // Create seeded RNG for rune card draws
         this.rng = this.createRng(this.playerData.seed! + '_runes')
 
+        // Restore state if returning from combat
+        if (this.pendingRestoreState) {
+            this.restoreDungeonState(this.pendingRestoreState)
+        }
+
         // Try fetching AI-enhanced layout (non-blocking)
         this.fetchAILayout()
 
         // Draw initial state
         this.drawMap()
         this.drawHUD()
-        this.drawRoomInfo(this.dungeon.nodes[0])
+        this.drawRoomInfo(this.dungeon.nodes[this.currentNodeId])
+
+        // Handle pending combat result after scene is drawn
+        if (this.pendingCombatResult) {
+            this.time.delayedCall(300, () => {
+                this.handleCombatResult(this.pendingCombatResult!)
+                this.pendingCombatResult = undefined
+                this.pendingRestoreState = undefined
+            })
+        }
+    }
+
+
+    // -----------------------------------------------------------------------
+    // State save / restore
+    // -----------------------------------------------------------------------
+
+    private saveDungeonState(combatNodeId: number): void {
+        const state: DungeonRestoreState = {
+            seed: this.playerData.seed!,
+            floor: this.floor,
+            currentNodeId: combatNodeId,
+            roomsCleared: this.roomsCleared,
+            visitedNodes: this.dungeon.nodes.filter(n => n.visited).map(n => n.id),
+            clearedNodes: this.dungeon.nodes.filter(n => n.cleared).map(n => n.id),
+            activeRunes: [...this.runeInventory.getActiveRunes()],
+            playerData: { ...this.playerData },
+            totalXpEarned: this.totalXpEarned,
+            totalCendresEarned: this.totalCendresEarned,
+        }
+        this.game.registry.set('dungeonState', state)
+    }
+
+    private restoreDungeonState(state: DungeonRestoreState): void {
+        this.currentNodeId = state.currentNodeId
+        for (const node of this.dungeon.nodes) {
+            if (state.visitedNodes.includes(node.id)) node.visited = true
+            if (state.clearedNodes.includes(node.id)) node.cleared = true
+        }
+        this.runeInventory.reset()
+        for (const rune of state.activeRunes) {
+            this.runeInventory.addRune(rune)
+        }
+        for (let i = 0; i < state.activeRunes.length * 2; i++) {
+            this.rng()
+        }
+    }
+
+    private handleCombatResult(result: CombatResult): void {
+        this.totalXpEarned += result.xpEarned
+        this.totalCendresEarned += result.cendresEarned
+
+        if (result.victory) {
+            const node = this.dungeon.nodes.find(n => n.id === result.nodeId)
+            if (node) {
+                node.cleared = true
+                node.visited = true
+                this.roomsCleared++
+            }
+            if (node && node.type === 'boss') {
+                this.scene.start('HubScene', {
+                    xpEarned: this.totalXpEarned,
+                    cendresEarned: this.totalCendresEarned,
+                })
+                return
+            }
+            this.drawMap()
+            this.drawHUD()
+            if (node) this.drawRoomInfo(node)
+            if (node && node.type === 'elite') {
+                this.time.delayedCall(500, () => this.showRuneCardSelection())
+            }
+        } else {
+            this.scene.start('HubScene', {
+                xpEarned: this.totalXpEarned,
+                cendresEarned: this.totalCendresEarned,
+            })
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -374,7 +499,9 @@ export class DungeonScene extends Phaser.Scene {
 
     private enterRoom(node: DungeonNode): void {
         if (node.type === 'combat' || node.type === 'elite' || node.type === 'boss') {
-            // Transition to CombatScene with room context
+            // Save dungeon state before transitioning to combat
+            this.saveDungeonState(node.id)
+
             this.scene.start('CombatScene', {
                 playerLevel: this.playerData.playerLevel,
                 talents: this.playerData.talents,
@@ -383,6 +510,7 @@ export class DungeonScene extends Phaser.Scene {
                     floor: this.floor,
                     roomType: node.type,
                     corruption: node.corruption,
+                    nodeId: node.id,
                     runeBuffs: this.runeInventory.getActiveRunes().map(r => ({
                         stat: r.effect.stat,
                         value: r.effect.value,
@@ -560,8 +688,8 @@ export class DungeonScene extends Phaser.Scene {
 
     private abandonRun(): void {
         this.scene.start('HubScene', {
-            xpEarned: this.roomsCleared * 15,
-            cendresEarned: this.roomsCleared * 10,
+            xpEarned: this.totalXpEarned + this.roomsCleared * 15,
+            cendresEarned: this.totalCendresEarned + this.roomsCleared * 10,
         })
     }
 

--- a/client/src/game/scenes/HubScene.ts
+++ b/client/src/game/scenes/HubScene.ts
@@ -286,7 +286,7 @@ export class HubScene extends Phaser.Scene {
     private startRun(): void {
         if (this.activeOverlay !== 'none') return
         this.savePlayerData()
-        this.scene.start('CombatScene', {
+        this.scene.start('DungeonScene', {
             playerLevel: this.playerData.level,
             talents: [...this.playerData.talents],
             inventory: [...this.playerData.inventory],

--- a/client/src/game/scenes/MainScene.ts
+++ b/client/src/game/scenes/MainScene.ts
@@ -1,156 +1,91 @@
 import Phaser from 'phaser'
+import { restoreSession, authenticateDevice } from '../../nakama/auth'
 
-const heroAsset = new URL('../assets/hero.svg', import.meta.url).href
-const crystalAsset = new URL('../assets/crystal.svg', import.meta.url).href
-
+/**
+ * MainScene — Title screen and entry point.
+ *
+ * Attempts to restore or create a Nakama session, then transitions
+ * to HubScene.  Works fully offline (auth failure is non-blocking).
+ */
 export class MainScene extends Phaser.Scene {
-  private player!: Phaser.Physics.Arcade.Sprite
-
-  private cursors!: Phaser.Types.Input.Keyboard.CursorKeys
-
-  private crystals!: Phaser.Physics.Arcade.Group
-
-  private scoreText!: Phaser.GameObjects.Text
-
-  private score = 0
-
-  private lastFacingAngle = 0
+  private statusText!: Phaser.GameObjects.Text
 
   constructor() {
     super({ key: 'MainScene' })
   }
 
-  preload() {
-    this.load.svg('hero', heroAsset, { scale: 2 })
-    this.load.svg('crystal', crystalAsset, { scale: 1.5 })
-
-    console.log('🎮 Project Umbra - Chargement des assets...')
-  }
-
   create() {
     const { width, height } = this.scale
+    this.cameras.main.setBackgroundColor(0x0f0f1a)
 
+    // Title
     this.add
-      .text(width / 2, 72, 'Project Umbra', {
-        fontSize: '40px',
+      .text(width / 2, height / 3 - 20, 'PROJECT UMBRA', {
+        fontSize: '48px',
         fontStyle: 'bold',
-        color: '#f5f6fa'
+        color: '#c8a2c8',
       })
       .setOrigin(0.5)
 
     this.add
-      .text(width / 2, 122, 'Collectez l\'énergie des cristaux', {
-        fontSize: '20px',
-        color: '#bdc3c7'
+      .text(width / 2, height / 3 + 40, 'Chronicles of the Fractured Realm', {
+        fontSize: '18px',
+        color: '#666666',
       })
       .setOrigin(0.5)
 
-    this.player = this.physics.add.sprite(width / 2, height / 2, 'hero')
-    this.player.setCollideWorldBounds(true)
-    this.player.setDamping(true)
-    this.player.setDrag(320)
-    this.player.setMaxVelocity(240)
+    // Start button
+    const startBtn = this.add
+      .text(width / 2, height / 2 + 60, '[ ENTER THE NEXUS ]', {
+        fontSize: '22px',
+        color: '#00ffaa',
+        fontStyle: 'bold',
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on('pointerover', () => startBtn.setColor('#ffffff'))
+      .on('pointerout', () => startBtn.setColor('#00ffaa'))
+      .on('pointerdown', () => this.startGame())
 
-    const cursors = this.input.keyboard?.createCursorKeys()
+    // ENTER shortcut
+    this.input.keyboard
+      ?.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER)
+      .on('down', () => this.startGame())
 
-    if (!cursors) {
-      throw new Error('Le clavier n\'est pas disponible dans cette scène')
-    }
+    // Status line (auth feedback)
+    this.statusText = this.add
+      .text(width / 2, height - 60, '', {
+        fontSize: '12px',
+        color: '#555555',
+      })
+      .setOrigin(0.5)
 
-    this.cursors = cursors
-
-    this.crystals = this.physics.add.group({
-      allowGravity: false
-    })
-
-    for (let i = 0; i < 5; i += 1) {
-      this.spawnCrystal()
-    }
-
-    this.physics.add.overlap(
-      this.player,
-      this.crystals,
-      this.collectCrystal,
-      undefined,
-      this
-    )
-
-    this.scoreText = this.add.text(24, 24, 'Énergie : 0', {
-      fontSize: '22px',
-      color: '#f5f6fa'
-    })
-
-    console.log('🎮 Project Umbra - Scène principale créée')
+    // Version
+    this.add
+      .text(width / 2, height - 30, 'v0.2.0 — Vertical Slice', {
+        fontSize: '12px',
+        color: '#333333',
+      })
+      .setOrigin(0.5)
   }
 
-  update() {
-    if (!this.player || !this.cursors) {
-      return
+  private async startGame(): Promise<void> {
+    this.statusText.setText('Connecting...')
+
+    try {
+      // Try restoring saved session first
+      const restored = restoreSession()
+      if (!restored) {
+        // Fall back to anonymous device auth
+        const deviceId =
+          localStorage.getItem('umbra_device_id') || crypto.randomUUID()
+        localStorage.setItem('umbra_device_id', deviceId)
+        await authenticateDevice(deviceId)
+      }
+    } catch {
+      // Offline — proceed without auth
     }
 
-    const body = this.player.body as Phaser.Physics.Arcade.Body
-    const speed = 240
-
-    body.setVelocity(0)
-
-    if (this.cursors.left?.isDown) {
-      body.setVelocityX(-speed)
-    } else if (this.cursors.right?.isDown) {
-      body.setVelocityX(speed)
-    }
-
-    if (this.cursors.up?.isDown) {
-      body.setVelocityY(-speed)
-    } else if (this.cursors.down?.isDown) {
-      body.setVelocityY(speed)
-    }
-
-    if (body.velocity.lengthSq() > 0) {
-      body.velocity.normalize().scale(speed)
-      this.lastFacingAngle = Math.atan2(body.velocity.y, body.velocity.x)
-    }
-
-    this.player.setRotation(this.lastFacingAngle)
-  }
-
-  private spawnCrystal() {
-    const { width, height } = this.scale
-    const x = Phaser.Math.Between(64, width - 64)
-    const y = Phaser.Math.Between(160, height - 64)
-
-    const crystal = this.crystals.create(x, y, 'crystal') as Phaser.Physics.Arcade.Sprite
-    crystal.setCircle(crystal.displayWidth / 2)
-    crystal.setImmovable(true)
-
-    return crystal
-  }
-
-  private collectCrystal: Phaser.Types.Physics.Arcade.ArcadePhysicsCallback = (
-    _player,
-    crystal
-  ) => {
-    if (!('body' in crystal)) {
-      return
-    }
-
-    const crystalSprite = crystal as Phaser.Physics.Arcade.Sprite
-    crystalSprite.disableBody(true, true)
-
-    this.score += 10
-    this.scoreText.setText(`Énergie : ${this.score}`)
-
-    this.time.delayedCall(1200, () => {
-      this.respawnCrystal(crystalSprite)
-    })
-  }
-
-  private respawnCrystal(crystal: Phaser.Physics.Arcade.Sprite) {
-    const { width, height } = this.scale
-    const x = Phaser.Math.Between(64, width - 64)
-    const y = Phaser.Math.Between(160, height - 64)
-
-    crystal.enableBody(true, x, y, true, true)
-    crystal.setCircle(crystal.displayWidth / 2)
-    crystal.setImmovable(true)
+    this.scene.start('HubScene')
   }
 }


### PR DESCRIPTION
## Summary
- **MainScene**: Converted from crystal demo to title screen with Nakama device auth and session restore
- **HubScene → DungeonScene**: Enter Dungeon now routes through procedural dungeon floor navigation
- **DungeonScene → CombatScene**: Combat/elite/boss rooms transition to CombatScene with full dungeon context (floor, corruption, rune buffs, nodeId) and `fromDungeon` flag
- **CombatScene → DungeonScene**: Victory returns to DungeonScene with combat result, restoring dungeon state via `game.registry`; room marked cleared, elite rooms offer rune cards
- **CombatScene defeat → HubScene**: Returns with partial XP/Cendres rewards
- **DungeonScene boss clear → HubScene**: Returns with full accumulated rewards
- **DungeonScene abandon → HubScene**: Returns with partial rewards including accumulated combat rewards

## Architecture
- Dungeon state serialized to `game.registry` before combat transition
- On return, DungeonScene regenerates deterministic dungeon from seed, then restores visited/cleared flags and rune inventory
- Standalone CombatScene mode preserved (victory → HubScene, defeat → restart)

## Test plan
- [ ] Launch game → title screen appears → click Enter → HubScene loads
- [ ] From HubScene, click Enter Dungeon → DungeonScene with minimap loads
- [ ] Navigate to combat room → click Enter Room → CombatScene starts
- [ ] Win combat → returns to DungeonScene with room marked CLEARED
- [ ] Lose combat → returns to HubScene with XP/Cendres rewards
- [ ] Clear boss room → returns to HubScene with full accumulated rewards
- [ ] Click Abandon Run → returns to HubScene with partial rewards
- [ ] Elite room victory → rune card selection offered

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)