### PR TITLE
feat: gacha UI overlay in HubScene with API integration (#71)

### DIFF
--- a/client/src/game/scenes/HubScene.ts
+++ b/client/src/game/scenes/HubScene.ts
@@ -1,4 +1,6 @@
 import Phaser from 'phaser'
+import { getGachaPools, drawGacha } from '../../services/game-logic'
+import type { GachaPool, GachaItem, GachaDrawResult } from '../../types/economy'
 import { nakamaClient, getSession } from '../../nakama/client'
 
 // ---------------------------------------------------------------------------
@@ -32,6 +34,7 @@ interface PlayerData {
     xpToNext: number
     cendres: number
     voidFragments: number
+    pityCounter: number
     talentPoints: number
     talents: number[]
     inventory: string[]
@@ -73,10 +76,14 @@ const NODE_POSITIONS = [
 export class HubScene extends Phaser.Scene {
     private playerData: PlayerData = {
         level: 1, xp: 0, xpToNext: 100, cendres: 100,
-        voidFragments: 0, talentPoints: 1, talents: [], inventory: [],
+        voidFragments: 0, pityCounter: 0, talentPoints: 1, talents: [], inventory: [],
     }
     private overlayGroup!: Phaser.GameObjects.Group
-    private activeOverlay: 'none' | 'shop' | 'talents' = 'none'
+    private activeOverlay: 'none' | 'shop' | 'talents' | 'gacha' = 'none'
+    private gachaPools: GachaPool[] = []
+    private selectedPool: GachaPool | null = null
+    private lastDrawResult: GachaDrawResult | null = null
+    private isDrawing = false
 
     constructor() {
         super({ key: 'HubScene' })
@@ -260,8 +267,287 @@ export class HubScene extends Phaser.Scene {
     }
 
     // -----------------------------------------------------------------------
+    // Gacha
+    // -----------------------------------------------------------------------
+
+    private async openGacha(): Promise<void> {
+        if (this.activeOverlay !== 'none') return
+        this.activeOverlay = 'gacha'
+        this.clearOverlay()
+
+        const bg = this.add.rectangle(512, 384, 750, 520, 0x111111, 0.95).setInteractive()
+        this.overlayGroup.add(bg)
+
+        this.overlayGroup.add(this.add.text(512, 150, 'VOID SUMMON', { fontSize: '24px', color: '#9370db', fontStyle: 'bold' }).setOrigin(0.5))
+        this.overlayGroup.add(this.add.text(512, 180, `Void Fragments: ${this.playerData.voidFragments}`, { fontSize: '16px', color: '#9370db' }).setOrigin(0.5))
+        this.overlayGroup.add(this.add.text(512, 200, `Pity: ${this.playerData.pityCounter} / 90`, { fontSize: '12px', color: '#888' }).setOrigin(0.5))
+
+        // Load pools if not cached
+        if (this.gachaPools.length === 0) {
+            try {
+                this.gachaPools = await getGachaPools()
+            } catch {
+                // Offline: use local fallback pool
+                this.gachaPools = [{
+                    id: 'standard',
+                    name: 'Standard Banner',
+                    items: [
+                        { id: 'rusty_blade', name: 'Rusty Blade', rarity: 'common', weight: 50, element: null },
+                        { id: 'recruit_sword', name: 'Recruit Sword', rarity: 'common', weight: 40, element: null },
+                        { id: 'flame_dagger', name: 'Flame Dagger', rarity: 'rare', weight: 20, element: 'fire' },
+                        { id: 'shadow_katana', name: 'Shadow Katana', rarity: 'rare', weight: 15, element: 'shadow' },
+                        { id: 'void_edge', name: 'Void Edge', rarity: 'epic', weight: 8, element: 'void' },
+                        { id: 'blood_reaper', name: 'Blood Reaper', rarity: 'epic', weight: 5, element: 'blood' },
+                        { id: 'corrupted_fang', name: 'Corrupted Fang', rarity: 'legendary', weight: 2, element: 'shadow' },
+                        { id: 'phoenix_blade', name: 'Phoenix Blade', rarity: 'legendary', weight: 1, element: 'fire' },
+                    ],
+                    pityThreshold: 90,
+                }]
+            }
+        }
+
+        if (this.lastDrawResult) {
+            this.showDrawResults()
+        } else {
+            this.showPoolSelection()
+        }
+
+        this.addCloseButton()
+    }
+
+    private showPoolSelection(): void {
+        // Clear previous pool UI (keep backdrop + header)
+        const poolY = 230
+        this.gachaPools.forEach((pool, i) => {
+            const py = poolY + i * 80
+            const poolBg = this.add.rectangle(512, py + 20, 600, 65, 0x222233, 0.9)
+                .setInteractive({ useHandCursor: true })
+                .on('pointerover', () => poolBg.setFillStyle(0x333344, 1))
+                .on('pointerout', () => poolBg.setFillStyle(0x222233, 0.9))
+                .on('pointerdown', () => { this.selectedPool = pool; this.showPoolDetail() })
+            this.overlayGroup.add(poolBg)
+
+            this.overlayGroup.add(this.add.text(250, py + 8, pool.name, { fontSize: '16px', color: '#fff', fontStyle: 'bold' }))
+            this.overlayGroup.add(this.add.text(250, py + 28, `${pool.items.length} items  |  Pity at ${pool.pityThreshold ?? 90}`, { fontSize: '12px', color: '#888' }))
+        })
+    }
+
+    private showPoolDetail(): void {
+        if (!this.selectedPool) return
+        this.closeOverlay()
+        this.activeOverlay = 'gacha'
+        this.clearOverlay()
+
+        const bg = this.add.rectangle(512, 384, 750, 520, 0x111111, 0.95).setInteractive()
+        this.overlayGroup.add(bg)
+
+        this.overlayGroup.add(this.add.text(512, 150, this.selectedPool.name.toUpperCase(), { fontSize: '22px', color: '#9370db', fontStyle: 'bold' }).setOrigin(0.5))
+        this.overlayGroup.add(this.add.text(512, 178, `Void Fragments: ${this.playerData.voidFragments}  |  Pity: ${this.playerData.pityCounter}/90`, { fontSize: '14px', color: '#aaa' }).setOrigin(0.5))
+
+        // Draw buttons
+        const canDraw1 = this.playerData.voidFragments >= 10
+        const canDraw10 = this.playerData.voidFragments >= 100
+
+        const draw1Btn = this.add.text(380, 220, 'Draw x1 (10 VF)', {
+            fontSize: '14px', color: canDraw1 ? '#9370db' : '#555',
+            backgroundColor: '#222', padding: { x: 12, y: 6 }
+        }).setOrigin(0.5)
+        if (canDraw1) {
+            draw1Btn.setInteractive({ useHandCursor: true })
+                .on('pointerdown', () => this.executeDraw(1))
+        }
+        this.overlayGroup.add(draw1Btn)
+
+        const draw10Btn = this.add.text(650, 220, 'Draw x10 (100 VF)', {
+            fontSize: '14px', color: canDraw10 ? '#ffd700' : '#555',
+            backgroundColor: '#222', padding: { x: 12, y: 6 }
+        }).setOrigin(0.5)
+        if (canDraw10) {
+            draw10Btn.setInteractive({ useHandCursor: true })
+                .on('pointerdown', () => this.executeDraw(10))
+        }
+        this.overlayGroup.add(draw10Btn)
+
+        // Back button
+        const backBtn = this.add.text(250, 150, '< Back', { fontSize: '14px', color: '#aaa' })
+            .setInteractive({ useHandCursor: true })
+            .on('pointerdown', () => { this.selectedPool = null; this.closeOverlay(); this.openGacha() })
+        this.overlayGroup.add(backBtn)
+
+        // Pool contents preview
+        this.overlayGroup.add(this.add.text(250, 260, 'Pool Contents:', { fontSize: '13px', color: '#888' }))
+        const rarityColors: Record<string, string> = { common: '#9ca3af', rare: '#3b82f6', epic: '#a855f7', legendary: '#f59e0b' }
+        this.selectedPool.items.forEach((item, i) => {
+            const iy = 285 + i * 22
+            if (iy > 500) return
+            const color = rarityColors[item.rarity] ?? '#fff'
+            this.overlayGroup.add(this.add.text(270, iy, item.name, { fontSize: '12px', color }))
+            this.overlayGroup.add(this.add.text(500, iy, item.rarity, { fontSize: '11px', color: '#666' }))
+            if (item.element) {
+                this.overlayGroup.add(this.add.text(580, iy, item.element, { fontSize: '11px', color: '#888' }))
+            }
+        })
+
+        this.addCloseButton()
+    }
+
+    // -----------------------------------------------------------------------
     // Overlay helpers
     // -----------------------------------------------------------------------
+
+    private async executeDraw(numDraws: number): Promise<void> {
+        if (!this.selectedPool || this.isDrawing) return
+        const cost = numDraws * 10
+        if (this.playerData.voidFragments < cost) return
+
+        this.isDrawing = true
+        this.playerData.voidFragments -= cost
+
+        try {
+            this.lastDrawResult = await drawGacha(
+                this.selectedPool.id,
+                numDraws,
+                this.playerData.pityCounter
+            )
+            this.playerData.pityCounter = this.lastDrawResult.newPityCounter
+        } catch {
+            // Offline fallback: local weighted random
+            const items = this.selectedPool.items
+            const drawn: GachaItem[] = []
+            for (let i = 0; i < numDraws; i++) {
+                const totalW = items.reduce((s, it) => s + it.weight, 0)
+                let roll = Math.random() * totalW
+                let pick = items[0]
+                for (const item of items) {
+                    roll -= item.weight
+                    if (roll <= 0) { pick = item; break }
+                }
+                drawn.push(pick)
+                this.playerData.pityCounter++
+                if (this.playerData.pityCounter >= 90) {
+                    // Force legendary on pity
+                    const legends = items.filter(it => it.rarity === 'legendary')
+                    if (legends.length > 0) {
+                        drawn[drawn.length - 1] = legends[Math.floor(Math.random() * legends.length)]
+                    }
+                    this.playerData.pityCounter = 0
+                }
+            }
+            this.lastDrawResult = {
+                items: drawn,
+                newPityCounter: this.playerData.pityCounter,
+                guaranteedLegendary: false,
+            }
+        }
+
+        // Add drawn items to inventory
+        for (const item of this.lastDrawResult.items) {
+            if (!this.playerData.inventory.includes(item.id)) {
+                this.playerData.inventory.push(item.id)
+            }
+        }
+
+        this.savePlayerData()
+        this.isDrawing = false
+
+        // Show results with draw animation
+        this.closeOverlay()
+        this.activeOverlay = 'gacha'
+        this.clearOverlay()
+        this.showDrawAnimation()
+    }
+
+    private showDrawAnimation(): void {
+        const bg = this.add.rectangle(512, 384, 750, 520, 0x0a0a15, 0.97).setInteractive()
+        this.overlayGroup.add(bg)
+
+        // Flash effect
+        const flash = this.add.rectangle(512, 384, 750, 520, 0x9370db, 0.6)
+        this.overlayGroup.add(flash)
+        this.tweens.add({
+            targets: flash,
+            alpha: 0,
+            duration: 600,
+            onComplete: () => {
+                flash.destroy()
+                this.showDrawResults()
+            }
+        })
+    }
+
+    private showDrawResults(): void {
+        if (!this.lastDrawResult) return
+
+        // Clear previous and re-draw backdrop
+        this.clearOverlay()
+        const bg = this.add.rectangle(512, 384, 750, 520, 0x111111, 0.95).setInteractive()
+        this.overlayGroup.add(bg)
+
+        this.overlayGroup.add(this.add.text(512, 150, 'SUMMON RESULTS', { fontSize: '22px', color: '#ffd700', fontStyle: 'bold' }).setOrigin(0.5))
+
+        if (this.lastDrawResult.guaranteedLegendary) {
+            this.overlayGroup.add(this.add.text(512, 175, 'PITY TRIGGERED!', { fontSize: '14px', color: '#f59e0b' }).setOrigin(0.5))
+        }
+
+        const rarityColors: Record<string, number> = { common: 0x9ca3af, rare: 0x3b82f6, epic: 0xa855f7, legendary: 0xf59e0b }
+        const rarityTextColors: Record<string, string> = { common: '#9ca3af', rare: '#3b82f6', epic: '#a855f7', legendary: '#f59e0b' }
+
+        const items = this.lastDrawResult.items
+        const cols = Math.min(items.length, 5)
+        // rows computed implicitly by col/index
+        const cardW = 120
+        const cardH = 140
+        const startX = 512 - (cols * (cardW + 10)) / 2 + cardW / 2
+
+        items.forEach((item, i) => {
+            const col = i % cols
+            const row = Math.floor(i / cols)
+            const cx = startX + col * (cardW + 10)
+            const cy = 260 + row * (cardH + 10)
+
+            // Card background
+            const cardBg = this.add.rectangle(cx, cy, cardW, cardH, 0x1a1a2e, 0.95)
+            this.overlayGroup.add(cardBg)
+
+            // Rarity border
+            const borderColor = rarityColors[item.rarity] ?? 0xffffff
+            const border = this.add.graphics()
+            border.lineStyle(2, borderColor, 1)
+            border.strokeRoundedRect(cx - cardW / 2, cy - cardH / 2, cardW, cardH, 6)
+            this.overlayGroup.add(border)
+
+            // Rarity glow for epic/legendary
+            if (item.rarity === 'epic' || item.rarity === 'legendary') {
+                const glow = this.add.rectangle(cx, cy, cardW - 4, cardH - 4, borderColor, 0.1)
+                this.overlayGroup.add(glow)
+                this.tweens.add({ targets: glow, alpha: 0.2, yoyo: true, repeat: -1, duration: 800 })
+            }
+
+            // Item name
+            const textColor = rarityTextColors[item.rarity] ?? '#fff'
+            this.overlayGroup.add(this.add.text(cx, cy - 30, item.name, { fontSize: '11px', color: textColor, fontStyle: 'bold', align: 'center', wordWrap: { width: cardW - 10 } }).setOrigin(0.5))
+
+            // Rarity
+            this.overlayGroup.add(this.add.text(cx, cy + 10, item.rarity.toUpperCase(), { fontSize: '10px', color: textColor }).setOrigin(0.5))
+
+            // Element
+            if (item.element) {
+                this.overlayGroup.add(this.add.text(cx, cy + 30, item.element, { fontSize: '10px', color: '#888' }).setOrigin(0.5))
+            }
+        })
+
+        // Pity counter
+        this.overlayGroup.add(this.add.text(512, 480, `Pity: ${this.playerData.pityCounter} / 90`, { fontSize: '12px', color: '#888' }).setOrigin(0.5))
+
+        // Continue button
+        const contBtn = this.add.text(512, 510, 'Continue', {
+            fontSize: '14px', color: '#9370db', backgroundColor: '#222', padding: { x: 16, y: 6 }
+        }).setOrigin(0.5).setInteractive({ useHandCursor: true })
+            .on('pointerdown', () => { this.lastDrawResult = null; this.closeOverlay(); this.openGacha() })
+        this.overlayGroup.add(contBtn)
+
+        this.addCloseButton()
+    }
 
     private addCloseButton(): void {
         const btn = this.add.text(790, 155, 'X', { fontSize: '20px', color: '#ff4444', fontStyle: 'bold' })


### PR DESCRIPTION
## Summary
- Add GACHA zone in HubScene (4-zone layout: Shop, Talents, Gacha, Dungeon)
- Pool selection screen listing available banners with item counts
- Pool detail view with x1 (10 VF) and x10 (100 VF) draw buttons
- Draw animation with purple flash effect
- Card-style results display with rarity-colored borders and glow effects
- Wire to `/api/v1/gacha/draw` endpoint with offline fallback (local weighted random)
- Pity counter tracking (90-pull guaranteed legendary)
- Void Fragments as gacha currency

## Test plan
- [ ] GACHA zone appears in hub alongside other zones
- [ ] Clicking GACHA opens pool selection overlay
- [ ] Selecting a pool shows draw buttons and item list
- [ ] x1 draw costs 10 VF, x10 costs 100 VF
- [ ] Draw animation plays, results show with rarity colors
- [ ] Pity counter increments and displays correctly
- [ ] Drawn items added to player inventory
- [ ] Offline mode: draws work with local fallback RNG
- [ ] Continue button returns to pool selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)